### PR TITLE
Add Kugou sync, resilient playback, live weather, and mini-player fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ backups/
 .env.*
 
 # Local development noise
+work/
 .DS_Store
 Thumbs.db
 desktop.ini

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -9,13 +9,14 @@ Mineradio 使用了以下第三方项目或服务。各项目版权归其原作�
 - GSAP
 - music-tempo
 - NeteaseCloudMusicApi
+- KuGouMusicApi（扫码登录与歌单接口签名流程参考，MIT License，Copyright (c) 2023 MakcRe）
 - mpg123-decoder
 
 ## Third-party Services
 
-Mineradio 可能与网易云音乐、QQ 音乐等第三方音乐服务进行用户自有账号相关的本地客户端交互。
+Mineradio 可能与网易云音乐、QQ 音乐、酷狗音乐等第三方音乐服务进行用户自有账号相关的本地客户端交互。
 
-Mineradio 不是任何音乐平台的官方客户端，也不隶属于网易云音乐、QQ 音乐或腾讯音乐娱乐集团。请用户自行遵守对应平台的服务协议、版权规则和会员权益规则。
+Mineradio 不是任何音乐平台的官方客户端，也不隶属于网易云音乐、QQ 音乐、酷狗音乐或腾讯音乐娱乐集团。请用户自行遵守对应平台的服务协议、版权规则和会员权益规则。
 
 ## Original Design
 

--- a/desktop/kugou-sync.js
+++ b/desktop/kugou-sync.js
@@ -1,0 +1,1156 @@
+/*
+ * The KuGou request-signing flow in this file was adapted from KuGouMusicApi.
+ * MIT License, Copyright (c) 2023 MakcRe
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const KUGOU_APP_ID = 1005;
+const KUGOU_WEB_APP_ID = 1014;
+const KUGOU_SOURCE_APP_ID = 2919;
+const KUGOU_CLIENT_VERSION = 20489;
+const KUGOU_SESSION_VERSION = 1;
+const KUGOU_LOGIN_MAX_AGE_MS = 10 * 60 * 1000;
+const KUGOU_MAX_PLAYLIST_PAGES = 10;
+const KUGOU_MAX_TRACK_PAGES = 20;
+const KUGOU_AUTH_ERROR_CODES = new Set(['20010', '20011', '20017', '10009']);
+const KUGOU_STREAM_KEY_SALT = '57ae12eb6890223e355ccfcb74edf70d';
+const KUGOU_STREAM_LEVELS = Object.freeze({
+  auto: [
+    { request: 'viper_clear', resolved: 'jymaster', label: '蝰蛇超清', fallbackBitRate: 0 },
+    { request: 'high', resolved: 'hires', label: 'Hi-Res', fallbackBitRate: 0 },
+    { request: 'flac', resolved: 'lossless', label: '无损 FLAC', fallbackBitRate: 0 },
+    { request: 320, resolved: 'exhigh', label: '极高 HQ', fallbackBitRate: 320000 },
+    { request: 128, resolved: 'standard', label: '标准', fallbackBitRate: 128000 },
+  ],
+  jymaster: [
+    { request: 'viper_clear', resolved: 'jymaster', label: '蝰蛇超清', fallbackBitRate: 0 },
+    { request: 'high', resolved: 'hires', label: 'Hi-Res', fallbackBitRate: 0 },
+    { request: 'flac', resolved: 'lossless', label: '无损 FLAC', fallbackBitRate: 0 },
+    { request: 320, resolved: 'exhigh', label: '极高 HQ', fallbackBitRate: 320000 },
+    { request: 128, resolved: 'standard', label: '标准', fallbackBitRate: 128000 },
+  ],
+  hires: [
+    { request: 'high', resolved: 'hires', label: 'Hi-Res', fallbackBitRate: 0 },
+    { request: 'flac', resolved: 'lossless', label: '无损 FLAC', fallbackBitRate: 0 },
+    { request: 320, resolved: 'exhigh', label: '极高 HQ', fallbackBitRate: 320000 },
+    { request: 128, resolved: 'standard', label: '标准', fallbackBitRate: 128000 },
+  ],
+  lossless: [
+    { request: 'flac', resolved: 'lossless', label: '无损 FLAC', fallbackBitRate: 0 },
+    { request: 320, resolved: 'exhigh', label: '极高 HQ', fallbackBitRate: 320000 },
+    { request: 128, resolved: 'standard', label: '标准', fallbackBitRate: 128000 },
+  ],
+  exhigh: [
+    { request: 320, resolved: 'exhigh', label: '极高 HQ', fallbackBitRate: 320000 },
+    { request: 128, resolved: 'standard', label: '标准', fallbackBitRate: 128000 },
+  ],
+  standard: [
+    { request: 128, resolved: 'standard', label: '标准', fallbackBitRate: 128000 },
+  ],
+});
+const KUGOU_BROWSER_AUDIO_FORMATS = new Set(['', 'mp3', 'flac', 'wav', 'ogg', 'm4a', 'aac']);
+const KUGOU_DEVICE_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDIAG7QOELSYoIJvTFJhMpe1s/gbjDJX51HBNnEl5HXqTW6lQ7LC8jr9fWZTwusknp+sVGzwd40MwP6U5yDE27M/X1+UR4tvOGOqp94TJtQ1EPnWGWXngpeIW5GxoQGao1rmYWAu6oi1z9XkChrsUdC6DJE5E221wf/4WLFxwAtRQIDAQAB
+-----END PUBLIC KEY-----`;
+
+function md5(value) {
+  return crypto.createHash('md5').update(String(value || ''), 'utf8').digest('hex');
+}
+
+function randomString(length) {
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  const bytes = crypto.randomBytes(length);
+  let output = '';
+  for (let index = 0; index < length; index += 1) output += alphabet[bytes[index] % alphabet.length];
+  return output;
+}
+
+function stableGuid(value) {
+  const hex = md5(`mineradio-kugou-guid:${value}`);
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-4${hex.slice(13, 16)}-a${hex.slice(17, 20)}-${hex.slice(20, 32)}`;
+}
+
+function normalizeStreamLevel(value) {
+  const level = String(value || '').toLowerCase();
+  return Object.prototype.hasOwnProperty.call(KUGOU_STREAM_LEVELS, level) ? level : 'auto';
+}
+
+function compactTrackIdentity(value) {
+  return String(value || '')
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/\.[a-z0-9]{2,5}$/i, '')
+    .replace(/[^\p{L}\p{N}]+/gu, '');
+}
+
+const TRACK_VERSION_RULES = Object.freeze([
+  { tag: 'remix', pattern: /\bremix(?:ed)?\b|重混|混音/iu },
+  { tag: 'dj', pattern: /\bdj\b|电音|舞曲/iu },
+  { tag: 'live', pattern: /\blive\b|现场(?:版)?|演唱会(?:版)?/iu },
+  { tag: 'cover', pattern: /\bcover\b|\btribute\b|翻唱|致敬/iu },
+  { tag: 'instrumental', pattern: /\binstrumental\b|伴奏|纯音乐|无人声/iu },
+  { tag: 'male', pattern: /男声|男版/iu },
+  { tag: 'female', pattern: /女声|女版/iu },
+  { tag: 'sped-up', pattern: /\bsped\s*up\b|加速|倍速|变速/iu },
+  { tag: 'slowed', pattern: /\bslowed\b|慢速|降速/iu },
+  { tag: 'acoustic', pattern: /\bacoustic\b|不插电|弹唱/iu },
+  { tag: 'demo', pattern: /\bdemo\b|试听/iu },
+  { tag: 'edit', pattern: /剪辑版|短版|片段版?/iu },
+  { tag: 'karaoke', pattern: /\bktv\b|卡拉\s*ok/iu },
+  { tag: 'remaster', pattern: /\bremaster(?:ed)?\b|重制/iu },
+  { tag: 'cantonese', pattern: /粤语/iu },
+  { tag: 'mandarin', pattern: /国语/iu },
+  { tag: 'english', pattern: /英文版?/iu },
+  { tag: 'japanese', pattern: /日语版?/iu },
+  { tag: 'korean', pattern: /韩语版?/iu },
+  { tag: 'piano', pattern: /钢琴(?:版)?|\bpiano\b/iu },
+  { tag: 'guitar', pattern: /吉他(?:版)?|\bguitar\b/iu },
+  { tag: 'traditional', pattern: /古筝版|琵琶版|二胡版|戏腔/iu },
+  { tag: 'original', pattern: /原唱|原版|\boriginal\b/iu },
+  { tag: 'studio', pattern: /录音室(?:版)?|\bstudio\b/iu },
+]);
+const NEUTRAL_TRACK_VERSION_TAGS = new Set(['original', 'studio']);
+
+function trackVersionSignals(value) {
+  const text = String(value || '').normalize('NFKC').toLowerCase();
+  const signals = new Set();
+  TRACK_VERSION_RULES.forEach((rule) => {
+    if (rule.pattern.test(text)) signals.add(rule.tag);
+  });
+  return signals;
+}
+
+function trackTitleBase(value) {
+  let text = String(value || '').normalize('NFKC').toLowerCase();
+  text = text.replace(/[（(【\[].*?[）)】\]]/gu, ' ');
+  TRACK_VERSION_RULES.forEach((rule) => {
+    const flags = rule.pattern.flags.includes('g') ? rule.pattern.flags : `${rule.pattern.flags}g`;
+    text = text.replace(new RegExp(rule.pattern.source, flags), ' ');
+  });
+  text = text.replace(/\b(?:version|ver)\.?\s*\d*\b|完整版|正式版|官方版|音频版|高音质|无损/giu, ' ');
+  return compactTrackIdentity(text);
+}
+
+function trackVersionSignalsMatch(expectedName, returnedName) {
+  const expected = trackVersionSignals(expectedName);
+  const returned = trackVersionSignals(returnedName);
+  NEUTRAL_TRACK_VERSION_TAGS.forEach((tag) => {
+    expected.delete(tag);
+    returned.delete(tag);
+  });
+  if (expected.size !== returned.size) return false;
+  for (const tag of expected) {
+    if (!returned.has(tag)) return false;
+  }
+  return true;
+}
+
+function splitStreamFileName(value) {
+  const fileName = String(value || '').trim().replace(/\.[a-z0-9]{2,5}$/i, '');
+  const parts = fileName.split(/\s+-\s+/);
+  if (parts.length < 2) return { artist: '', name: fileName };
+  return {
+    artist: parts.shift().trim(),
+    name: parts.join(' - ').trim(),
+  };
+}
+
+function splitArtistIdentities(value) {
+  return String(value || '')
+    .split(/\s*(?:\/|、|,|，|&|＆|;|；|\+|\bx\b|\bfeat\.?\b|\bft\.?\b)\s*/i)
+    .map(compactTrackIdentity)
+    .filter(Boolean);
+}
+
+function stripArtistPrefixFromTitle(value, artistValue) {
+  const original = String(value || '').trim();
+  const split = splitStreamFileName(original);
+  if (!split.artist || !split.name) return original;
+  const prefixArtists = splitArtistIdentities(split.artist);
+  const expectedArtists = splitArtistIdentities(artistValue);
+  if (!prefixArtists.length || !expectedArtists.length) return original;
+  return prefixArtists.some((artist) => expectedArtists.includes(artist)) ? split.name : original;
+}
+
+function streamIdentityMatches(fileName, expectedName, expectedArtist) {
+  const cleanExpectedName = stripArtistPrefixFromTitle(expectedName, expectedArtist);
+  const expectedTitle = trackTitleBase(cleanExpectedName);
+  if (!expectedTitle) return true;
+  const returned = splitStreamFileName(fileName);
+  if (!returned.name || trackTitleBase(returned.name) !== expectedTitle) return false;
+  if (!trackVersionSignalsMatch(cleanExpectedName, returned.name)) return false;
+  const expectedArtists = splitArtistIdentities(expectedArtist);
+  const returnedArtists = splitArtistIdentities(returned.artist);
+  if (!expectedArtists.length || !returnedArtists.length) return true;
+  return expectedArtists.some((artist) => returnedArtists.includes(artist));
+}
+
+function searchTrackIdentityScore(track, expectedName, expectedArtist) {
+  if (!track || typeof track !== 'object') return -1;
+  const cleanExpectedName = stripArtistPrefixFromTitle(expectedName, expectedArtist);
+  const cleanTrackName = stripArtistPrefixFromTitle(track.name, track.artist);
+  if (!trackTitleBase(cleanExpectedName) || trackTitleBase(cleanTrackName) !== trackTitleBase(cleanExpectedName)) return -1;
+  const versionText = [cleanTrackName, track.versionText, track.album].filter(Boolean).join(' ');
+  if (!trackVersionSignalsMatch(cleanExpectedName, versionText)) return -1;
+  const expectedArtists = splitArtistIdentities(expectedArtist);
+  const returnedArtists = splitArtistIdentities(track.artist);
+  if (expectedArtists.length && returnedArtists.length
+      && !expectedArtists.some((artist) => returnedArtists.includes(artist))) return -1;
+  let score = 100;
+  if (compactTrackIdentity(cleanTrackName) === compactTrackIdentity(cleanExpectedName)) score += 20;
+  if (compactTrackIdentity(track.artist) === compactTrackIdentity(expectedArtist)) score += 30;
+  else if (expectedArtists.some((artist) => returnedArtists.includes(artist))) score += 18;
+  if (track.fileName && streamIdentityMatches(track.fileName, cleanExpectedName, expectedArtist)) score += 12;
+  return score;
+}
+
+function uniqueStreamIdVariants(albumId, albumAudioId) {
+  const variants = [
+    { albumId, albumAudioId },
+    { albumId, albumAudioId: 0 },
+    { albumId: 0, albumAudioId },
+    { albumId: 0, albumAudioId: 0 },
+  ];
+  const seen = new Set();
+  return variants.filter((item) => {
+    const key = `${item.albumId}:${item.albumAudioId}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function encryptDevicePayload(data) {
+  const key = randomString(6);
+  const digest = md5(key);
+  const cipher = crypto.createCipheriv(
+    'aes-128-cbc',
+    Buffer.from(digest.slice(0, 16), 'utf8'),
+    Buffer.from(digest.slice(16, 32), 'utf8'),
+  );
+  const encrypted = Buffer.concat([cipher.update(JSON.stringify(data), 'utf8'), cipher.final()]);
+  return { key, data: encrypted.toString('base64') };
+}
+
+function decryptDevicePayload(buffer, key) {
+  const digest = md5(key);
+  const decipher = crypto.createDecipheriv(
+    'aes-128-cbc',
+    Buffer.from(digest.slice(0, 16), 'utf8'),
+    Buffer.from(digest.slice(16, 32), 'utf8'),
+  );
+  const decrypted = Buffer.concat([decipher.update(buffer), decipher.final()]).toString('utf8');
+  return JSON.parse(decrypted);
+}
+
+function signatureWeb(params) {
+  const salt = 'NVPh5oo715z5DIWAeQlhMDsWXXQV4hwt';
+  const serialized = Object.keys(params)
+    .map((key) => `${key}=${params[key]}`)
+    .sort()
+    .join('');
+  return md5(`${salt}${serialized}${salt}`);
+}
+
+function signatureAndroid(params, dataText) {
+  const salt = 'OIlwieks28dk2k092lksi2UIkp';
+  const serialized = Object.keys(params)
+    .sort()
+    .map((key) => `${key}=${typeof params[key] === 'object' ? JSON.stringify(params[key]) : params[key]}`)
+    .join('');
+  return md5(`${salt}${serialized}${dataText || ''}${salt}`);
+}
+
+function firstValue(source, keys, fallback = '') {
+  if (!source || typeof source !== 'object') return fallback;
+  for (const key of keys) {
+    const value = source[key];
+    if (value !== undefined && value !== null && String(value).trim()) return value;
+  }
+  return fallback;
+}
+
+function imageUrl(value, size = 240) {
+  const url = String(value || '').trim();
+  if (!url) return '';
+  return url.replace(/\{size\}/g, String(size)).replace(/^http:\/\//i, 'https://');
+}
+
+function cleanTrackText(value) {
+  return String(value || '')
+    .replace(/<\/?em\b[^>]*>/gi, '')
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .trim();
+}
+
+function apiError(body, fallback) {
+  const code = firstValue(body, ['error_code', 'errcode', 'code'], 'KUGOU_REQUEST_FAILED');
+  const message = firstValue(body, ['error_msg', 'errmsg', 'msg', 'message'], fallback || `KUGOU_API_${code}`);
+  const error = new Error(typeof message === 'string' ? message : fallback || 'KUGOU_REQUEST_FAILED');
+  error.code = String(code);
+  return error;
+}
+
+function normalizePlaylist(raw, userId) {
+  if (!raw || typeof raw !== 'object') return null;
+  const globalId = String(firstValue(raw, [
+    'global_collection_id',
+    'list_create_gid',
+    'parent_global_collection_id',
+    'collection_id',
+  ], '') || '');
+  const listId = String(firstValue(raw, ['listid', 'list_id', 'list_create_listid', 'specialid'], '') || '');
+  const id = globalId || listId;
+  const name = String(firstValue(raw, ['name', 'listname', 'specialname', 'title'], '') || '').trim();
+  if (!id || !name) return null;
+  const ownerId = String(firstValue(raw, ['list_create_userid', 'userid', 'user_id'], '') || '');
+  const mine = Number(raw.is_mine) === 1 || (!!ownerId && ownerId === String(userId || ''));
+  const count = Number(firstValue(raw, ['count', 'song_count', 'songs_count', 'track_count', 'total'], 0)) || 0;
+  return {
+    id,
+    globalId,
+    listId,
+    name,
+    cover: imageUrl(firstValue(raw, ['pic', 'imgurl', 'cover', 'image'], '')),
+    trackCount: count,
+    creator: String(firstValue(raw, ['list_create_username', 'username', 'nickname', 'creator'], mine ? '我的酷狗账号' : '酷狗音乐') || ''),
+    subscribed: !mine,
+  };
+}
+
+function collectPlaylistCandidates(value, userId, output, depth = 0) {
+  if (depth > 5 || value == null) return;
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectPlaylistCandidates(item, userId, output, depth + 1));
+    return;
+  }
+  if (typeof value !== 'object') return;
+  const playlist = normalizePlaylist(value, userId);
+  if (playlist) output.push(playlist);
+  Object.keys(value).forEach((key) => {
+    const child = value[key];
+    if (child && typeof child === 'object') collectPlaylistCandidates(child, userId, output, depth + 1);
+  });
+}
+
+function normalizeTrack(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  let artist = '';
+  const singerRows = Array.isArray(raw.singerinfo) ? raw.singerinfo : (Array.isArray(raw.Singers) ? raw.Singers : []);
+  if (singerRows.length) {
+    artist = singerRows
+      .map((item) => firstValue(item, ['name', 'Name', 'singername', 'SingerName'], ''))
+      .filter(Boolean)
+      .join(' / ');
+  }
+  artist = cleanTrackText(artist || firstValue(raw, [
+    'author_name', 'singername', 'singer_name', 'artist', 'singer', 'SingerName',
+  ], ''));
+  let name = cleanTrackText(firstValue(raw, [
+    'name', 'songname', 'audio_name', 'OriSongName', 'SongName', 'AudioName', 'filename', 'FileName',
+  ], ''));
+  name = stripArtistPrefixFromTitle(name, artist);
+  if (!artist && name.includes(' - ')) {
+    const parts = name.split(' - ');
+    artist = parts.shift().trim();
+    name = parts.join(' - ').trim();
+  }
+  if (!name) return null;
+  const albumInfo = raw.albuminfo && typeof raw.albuminfo === 'object'
+    ? raw.albuminfo
+    : (raw.AlbumInfo && typeof raw.AlbumInfo === 'object' ? raw.AlbumInfo : {});
+  const durationMs = Number(firstValue(raw, ['timelen', 'duration', 'duration_ms', 'Duration'], 0)) || 0;
+  return {
+    id: String(firstValue(raw, ['audio_id', 'Audioid', 'mixsongid', 'MixSongID', 'fileid', 'hash', 'FileHash'], '') || ''),
+    hash: String(firstValue(raw, ['hash', 'FileHash'], '') || ''),
+    albumId: String(firstValue(
+      raw,
+      ['album_id', 'albumid', 'AlbumID'],
+      firstValue(albumInfo, ['id', 'album_id', 'AlbumID'], '0'),
+    ) || '0'),
+    albumAudioId: String(firstValue(raw, ['album_audio_id', 'audio_id', 'Audioid', 'mixsongid', 'MixSongID'], '0') || '0'),
+    name,
+    artist: artist || '未知歌手',
+    album: cleanTrackText(firstValue(albumInfo, ['name', 'Name'], firstValue(raw, ['album_name', 'album', 'AlbumName'], ''))),
+    duration: durationMs > 10000 ? Math.round(durationMs / 1000) : durationMs,
+    cover: imageUrl(firstValue(
+      raw,
+      ['cover', 'album_img', 'imgurl', 'Image', 'AlbumImage'],
+      firstValue(raw.trans_param, ['union_cover'], ''),
+    )),
+    fileName: cleanTrackText(firstValue(raw, ['filename', 'FileName'], '')),
+    versionText: cleanTrackText(firstValue(raw, ['OtherName', 'Suffix', 'Auxiliary', 'TagContent'], '')),
+  };
+}
+
+function searchTrackRows(body) {
+  const data = body && body.data && typeof body.data === 'object' ? body.data : body;
+  const candidates = [
+    data && data.info,
+    data && data.lists,
+    data && data.items,
+    data && data.songs,
+    body && body.info,
+  ];
+  for (const rows of candidates) {
+    if (Array.isArray(rows)) return rows;
+  }
+  return [];
+}
+
+function sessionPublicView(session, persistent = true) {
+  if (!session || !session.userid || !session.token) {
+    return { ok: true, loggedIn: false, persistent };
+  }
+  return {
+    ok: true,
+    loggedIn: true,
+    persistent,
+    userid: String(session.userid),
+    nickname: String(session.nickname || `酷狗用户 ${session.userid}`),
+    avatar: imageUrl(session.avatar || '', 180),
+  };
+}
+
+function createKugouSync(options) {
+  const fetchImpl = options && options.fetchImpl;
+  const userDataPath = options && options.userDataPath;
+  const safeStorage = options && options.safeStorage;
+  if (typeof fetchImpl !== 'function') throw new Error('KUGOU_FETCH_UNAVAILABLE');
+  if (!userDataPath) throw new Error('KUGOU_USER_DATA_PATH_EMPTY');
+
+  const sessionFile = path.join(userDataPath, 'kugou-session-v1.json');
+  const mid = md5(`mineradio-kugou:${path.resolve(userDataPath)}`);
+  let cachedSession;
+  let pendingLogin = null;
+
+  function encryptionAvailable() {
+    try {
+      return !!(safeStorage && safeStorage.isEncryptionAvailable());
+    } catch (_e) {
+      return false;
+    }
+  }
+
+  function readSession() {
+    if (cachedSession !== undefined) return cachedSession;
+    cachedSession = null;
+    try {
+      if (!fs.existsSync(sessionFile) || !encryptionAvailable()) return cachedSession;
+      const stored = JSON.parse(fs.readFileSync(sessionFile, 'utf8'));
+      if (!stored || stored.version !== KUGOU_SESSION_VERSION || !stored.data) return cachedSession;
+      const decrypted = safeStorage.decryptString(Buffer.from(stored.data, 'base64'));
+      const session = JSON.parse(decrypted);
+      if (session && session.userid && session.token) cachedSession = session;
+    } catch (_e) {
+      cachedSession = null;
+    }
+    return cachedSession;
+  }
+
+  function writeSession(session) {
+    cachedSession = session && session.userid && session.token ? session : null;
+    if (!cachedSession || !encryptionAvailable()) return false;
+    const encrypted = safeStorage.encryptString(JSON.stringify(cachedSession));
+    fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+    fs.writeFileSync(sessionFile, JSON.stringify({
+      version: KUGOU_SESSION_VERSION,
+      encrypted: true,
+      data: encrypted.toString('base64'),
+    }), { encoding: 'utf8', mode: 0o600 });
+    return true;
+  }
+
+  function clearSession() {
+    cachedSession = null;
+    pendingLogin = null;
+    try {
+      if (fs.existsSync(sessionFile)) fs.unlinkSync(sessionFile);
+    } catch (_e) {}
+  }
+
+  async function request({ baseURL = 'https://gateway.kugou.com', url, method = 'GET', params, data, encryptType = 'android', headers, cookie, responseType, encryptKey, clearDefaultParams = false, notSign = false }) {
+    const clienttime = Math.floor(Date.now() / 1000);
+    const requestCookie = cookie && typeof cookie === 'object' ? cookie : {};
+    const requestDfid = String(requestCookie.dfid || '-');
+    const requestMid = String(requestCookie.mid || mid);
+    const requestGuid = String(requestCookie.guid || requestCookie.KUGOU_API_GUID || '-');
+    const defaults = clearDefaultParams ? {} : {
+      dfid: requestDfid,
+      mid: requestMid,
+      uuid: requestGuid,
+      appid: KUGOU_APP_ID,
+      clientver: KUGOU_CLIENT_VERSION,
+      clienttime,
+    };
+    if (!clearDefaultParams && requestCookie.token) defaults.token = requestCookie.token;
+    if (!clearDefaultParams && requestCookie.userid) defaults.userid = requestCookie.userid;
+    const query = Object.assign({}, defaults, params || {});
+    const dataText = data && typeof data === 'object' ? JSON.stringify(data) : String(data || '');
+    if (encryptKey) {
+      query.key = md5(`${String(query.hash || '')}${KUGOU_STREAM_KEY_SALT}${query.appid}${query.mid}${query.userid || 0}`);
+    }
+    if (!notSign) query.signature = encryptType === 'web' ? signatureWeb(query) : signatureAndroid(query, dataText);
+    const target = new URL(url, baseURL);
+    Object.keys(query).forEach((key) => {
+      if (query[key] !== undefined && query[key] !== null) target.searchParams.set(key, String(query[key]));
+    });
+    const response = await fetchImpl(target.toString(), {
+      method,
+      headers: Object.assign({
+        'User-Agent': 'Android15-1070-11083-46-0-DiscoveryDRADProtocol-wifi',
+        'Content-Type': 'application/json',
+        dfid: requestDfid,
+        mid: requestMid,
+        clienttime: String(clienttime),
+        'kg-rc': '1',
+        'kg-thash': '5d816a0',
+        'kg-rec': '1',
+        'kg-rf': 'B9EDA08A64250DEFFBCADDEE00F8F25F',
+      }, headers || {}),
+      body: method.toUpperCase() === 'GET' || method.toUpperCase() === 'HEAD' ? undefined : dataText,
+    });
+    if (responseType === 'arrayBuffer') {
+      const buffer = Buffer.from(await response.arrayBuffer());
+      if (!response.ok) throw new Error(`KUGOU_HTTP_${response.status}`);
+      return buffer;
+    }
+    if (responseType === 'text') {
+      const text = await response.text();
+      if (!response.ok) throw new Error(`KUGOU_HTTP_${response.status}`);
+      return text;
+    }
+    const text = await response.text();
+    let body;
+    try {
+      body = JSON.parse(text);
+    } catch (_e) {
+      throw new Error('KUGOU_RESPONSE_INVALID');
+    }
+    if (!response.ok || Number(body.status) === 0 || (body.error_code !== undefined && Number(body.error_code) !== 0)) {
+      const error = apiError(body, `KUGOU_HTTP_${response.status}`);
+      if (KUGOU_AUTH_ERROR_CODES.has(String(error.code))) clearSession();
+      throw error;
+    }
+    return body;
+  }
+
+  async function ensureRegisteredDevice(session) {
+    if (!session) throw new Error('KUGOU_NOT_LOGGED_IN');
+    if (!session.guid) session.guid = stableGuid(path.resolve(userDataPath));
+    if (session.dfid && session.dfid !== '-') {
+      writeSession(session);
+      return session;
+    }
+    const devicePayload = {
+      availableRamSize: 4983533568,
+      availableRomSize: 48114719,
+      availableSDSize: 48114717,
+      basebandVer: '',
+      batteryLevel: 100,
+      batteryStatus: 3,
+      brand: 'Redmi',
+      buildSerial: 'unknown',
+      device: 'marble',
+      imei: session.guid,
+      imsi: '',
+      manufacturer: 'Xiaomi',
+      uuid: session.guid,
+      accelerometer: false,
+      accelerometerValue: '',
+      gravity: false,
+      gravityValue: '',
+      gyroscope: false,
+      gyroscopeValue: '',
+      light: false,
+      lightValue: '',
+      magnetic: false,
+      magneticValue: '',
+      orientation: false,
+      orientationValue: '',
+      pressure: false,
+      pressureValue: '',
+      step_counter: false,
+      step_counterValue: '',
+      temperature: false,
+      temperatureValue: '',
+    };
+    const encrypted = encryptDevicePayload(devicePayload);
+    const encryptedSession = crypto.publicEncrypt({
+      key: KUGOU_DEVICE_PUBLIC_KEY,
+      padding: crypto.constants.RSA_PKCS1_PADDING,
+    }, Buffer.from(JSON.stringify({ aes: encrypted.key, uid: session.userid, token: session.token }), 'utf8')).toString('hex');
+    const responseBuffer = await request({
+      baseURL: 'https://userservice.kugou.com',
+      url: '/risk/v2/r_register_dev',
+      method: 'POST',
+      params: { part: 1, platid: 1, p: encryptedSession },
+      data: encrypted.data,
+      cookie: session,
+      responseType: 'arrayBuffer',
+    });
+    const body = decryptDevicePayload(responseBuffer, encrypted.key);
+    const dfid = String(body && body.data && body.data.dfid || '');
+    if (Number(body && body.status) !== 1 || !dfid) throw apiError(body, 'KUGOU_DEVICE_REGISTER_FAILED');
+    session.dfid = dfid;
+    session.updatedAt = Date.now();
+    writeSession(session);
+    return session;
+  }
+
+  async function findSearchFallbackTracks(expectedName, expectedArtist) {
+    const cleanName = stripArtistPrefixFromTitle(expectedName, expectedArtist);
+    if (!trackTitleBase(cleanName)) return [];
+    const firstArtist = String(expectedArtist || '')
+      .split(/\s*(?:\/|、|,|，|&|＆|;|；|\+|\bx\b|\bfeat\.?\b|\bft\.?\b)\s*/i)
+      .map((value) => value.trim())
+      .find(Boolean) || '';
+    const queries = [];
+    const combined = `${cleanName} ${firstArtist}`.trim();
+    if (combined) queries.push(combined);
+    if (cleanName && cleanName !== combined) queries.push(cleanName);
+    const candidates = new Map();
+    for (let queryIndex = 0; queryIndex < queries.length; queryIndex += 1) {
+      const result = await searchTracks({ query: queries[queryIndex], page: 1, pageSize: 30 });
+      const tracks = Array.isArray(result && result.tracks) ? result.tracks : [];
+      tracks.forEach((candidate) => {
+        const score = searchTrackIdentityScore(candidate, cleanName, expectedArtist);
+        if (score < 0) return;
+        const key = String(candidate.hash || '').toLowerCase();
+        const previous = candidates.get(key);
+        if (!previous || score > previous.score) candidates.set(key, { track: candidate, score });
+      });
+      if (candidates.size >= 3) break;
+    }
+    return Array.from(candidates.values())
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 4)
+      .map((item) => item.track);
+  }
+
+  async function getStreamUrl(track, internalOptions) {
+    internalOptions = internalOptions || {};
+    let session = readSession();
+    if (!session) return { ok: false, loggedIn: false, error: 'KUGOU_NOT_LOGGED_IN' };
+    const hash = String(track && track.hash || '').trim().toLowerCase();
+    if (!/^[a-f0-9]{32}$/.test(hash)) return { ok: false, error: 'KUGOU_TRACK_HASH_INVALID' };
+    session = await ensureRegisteredDevice(session);
+    const albumId = Number(track && track.albumId) || 0;
+    const albumAudioId = Number(track && track.albumAudioId) || 0;
+    const expectedName = String(track && track.name || '').trim();
+    const expectedArtist = String(track && track.artist || '').trim();
+    const requestedLevel = normalizeStreamLevel(track && track.quality);
+    const qualityCandidates = KUGOU_STREAM_LEVELS[requestedLevel];
+    const idVariants = uniqueStreamIdVariants(albumId, albumAudioId);
+    let lastError = null;
+    let identityMismatchError = null;
+    for (let qualityIndex = 0; qualityIndex < qualityCandidates.length; qualityIndex += 1) {
+      const qualityCandidate = qualityCandidates[qualityIndex];
+      for (let variantIndex = 0; variantIndex < idVariants.length; variantIndex += 1) {
+        const idVariant = idVariants[variantIndex];
+        try {
+          const body = await request({
+            url: '/v5/url',
+            params: {
+              album_id: idVariant.albumId,
+              area_code: 1,
+              hash,
+              ssa_flag: 'is_fromtrack',
+              version: 11430,
+              page_id: 151369488,
+              quality: qualityCandidate.request,
+              album_audio_id: idVariant.albumAudioId,
+              behavior: 'play',
+              pid: 2,
+              cmd: 26,
+              pidversion: 3001,
+              IsFreePart: 0,
+              ppage_id: '463467626,350369493,788954147',
+              cdnBackup: 1,
+              module: '',
+              clientver: 11430,
+            },
+            headers: { 'x-router': 'trackercdn.kugou.com' },
+            cookie: session,
+            encryptKey: true,
+          });
+          const candidates = []
+            .concat(Array.isArray(body && body.url) ? body.url : [])
+            .concat(Array.isArray(body && body.backupUrl) ? body.backupUrl : [])
+            .filter((value) => /^https?:\/\//i.test(String(value || '')));
+          const format = String(body && body.extName || '').replace(/^\./, '').toLowerCase();
+          const fileName = String(body && body.fileName || '').trim();
+          if (candidates.length && KUGOU_BROWSER_AUDIO_FORMATS.has(format)) {
+            if (!streamIdentityMatches(fileName, expectedName, expectedArtist)) {
+              const mismatchError = new Error('KUGOU_STREAM_IDENTITY_MISMATCH');
+              mismatchError.code = 'KUGOU_STREAM_IDENTITY_MISMATCH';
+              mismatchError.actualFileName = fileName.slice(0, 300);
+              identityMismatchError = mismatchError;
+              lastError = mismatchError;
+              continue;
+            }
+            return {
+              ok: true,
+              loggedIn: true,
+              url: String(candidates[0]),
+              requestedLevel,
+              resolvedLevel: qualityCandidate.resolved,
+              qualityLabel: qualityCandidate.label,
+              downgraded: requestedLevel !== 'auto' && qualityIndex > 0,
+              bitRate: Number(body.bitRate) || qualityCandidate.fallbackBitRate,
+              duration: Number(body.timeLength) || 0,
+              format,
+              fileName,
+              identityVerified: !!expectedName,
+            };
+          }
+          lastError = new Error(candidates.length ? 'KUGOU_STREAM_FORMAT_UNSUPPORTED' : 'KUGOU_STREAM_URL_EMPTY');
+        } catch (error) {
+          lastError = error;
+        }
+      }
+    }
+    if (!internalOptions.skipSearchFallback && expectedName) {
+      try {
+        const fallbackTracks = await findSearchFallbackTracks(expectedName, expectedArtist);
+        for (let fallbackIndex = 0; fallbackIndex < fallbackTracks.length; fallbackIndex += 1) {
+          const fallbackTrack = fallbackTracks[fallbackIndex];
+          const sameHash = String(fallbackTrack.hash || '').toLowerCase() === hash;
+          const sameIds = Number(fallbackTrack.albumId) === albumId
+            && Number(fallbackTrack.albumAudioId) === albumAudioId;
+          if (sameHash && sameIds) continue;
+          try {
+            const fallbackResult = await getStreamUrl({
+              ...fallbackTrack,
+              name: expectedName,
+              artist: expectedArtist || fallbackTrack.artist,
+              quality: requestedLevel,
+            }, { skipSearchFallback: true });
+            return {
+              ...fallbackResult,
+              matchedBySearch: true,
+              matchedTrack: {
+                hash: fallbackTrack.hash,
+                albumId: fallbackTrack.albumId,
+                albumAudioId: fallbackTrack.albumAudioId,
+              },
+            };
+          } catch (fallbackError) {
+            lastError = fallbackError;
+          }
+        }
+      } catch (searchError) {
+        if (!lastError) lastError = searchError;
+      }
+    }
+    throw identityMismatchError || lastError || new Error('KUGOU_STREAM_URL_EMPTY');
+  }
+
+  async function searchTracks(input) {
+    let session = readSession();
+    if (!session) return { ok: false, loggedIn: false, error: 'KUGOU_NOT_LOGGED_IN', tracks: [] };
+    const keyword = String(input && (input.query || input.keyword) || '').trim().slice(0, 120);
+    if (!keyword) return { ok: true, loggedIn: true, tracks: [], total: 0 };
+    const page = Math.max(1, Math.min(20, Number(input && input.page) || 1));
+    const pageSize = Math.max(1, Math.min(30, Number(input && input.pageSize) || 20));
+    session = await ensureRegisteredDevice(session);
+    const body = await request({
+      url: '/v3/search/song',
+      params: {
+        albumhide: 0,
+        iscorrection: 1,
+        keyword,
+        nocollect: 0,
+        page,
+        pagesize: pageSize,
+        platform: 'AndroidFilter',
+      },
+      headers: { 'x-router': 'complexsearch.kugou.com' },
+      cookie: session,
+    });
+    const rows = searchTrackRows(body);
+    const tracks = [];
+    const seen = new Set();
+    for (const row of rows) {
+      const track = normalizeTrack(row);
+      if (!track || !/^[a-f0-9]{32}$/i.test(track.hash)) continue;
+      const key = String(track.hash).toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      tracks.push(track);
+    }
+    const data = body && body.data && typeof body.data === 'object' ? body.data : {};
+    const total = Number(firstValue(data, ['total', 'total_count', 'count'], tracks.length)) || tracks.length;
+    return { ok: true, loggedIn: true, tracks, total, page, pageSize };
+  }
+
+  async function getLyrics(track) {
+    let session = readSession();
+    if (!session) return { ok: false, loggedIn: false, error: 'KUGOU_NOT_LOGGED_IN', lyric: '' };
+    const hash = String(track && track.hash || '').trim().toUpperCase();
+    const albumAudioId = Math.max(0, Number(track && track.albumAudioId) || 0);
+    const duration = Math.max(0, Math.round(Number(track && track.duration) || 0));
+    const name = String(track && track.name || '').trim().slice(0, 300);
+    const artist = String(track && track.artist || '').trim().slice(0, 300);
+    if (!hash && !albumAudioId && !name) return { ok: false, loggedIn: true, error: 'KUGOU_LYRIC_ID_EMPTY', lyric: '' };
+    session = await ensureRegisteredDevice(session);
+    const getLegacyLyrics = async () => {
+      if (!hash) return '';
+      const text = await request({
+        baseURL: 'https://m.kugou.com',
+        url: '/app/i/krc.php',
+        params: {
+          cmd: 100,
+          hash,
+          timelength: duration > 0 ? duration * 1000 : 0,
+        },
+        headers: {
+          Referer: 'https://www.kugou.com/',
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Mineradio/1.0',
+        },
+        responseType: 'text',
+        clearDefaultParams: true,
+        notSign: true,
+      });
+      return String(text || '').replace(/^\uFEFF/, '').trim();
+    };
+    let searchBody;
+    try {
+      searchBody = await request({
+        baseURL: 'https://lyrics.kugou.com',
+        url: '/v1/search',
+        params: {
+          album_audio_id: albumAudioId,
+          appid: KUGOU_APP_ID,
+          clientver: KUGOU_CLIENT_VERSION,
+          duration,
+          hash,
+          keyword: [name, artist].filter(Boolean).join(' - '),
+          lrctxt: 1,
+          man: 'no',
+        },
+        headers: {
+          Referer: 'https://www.kugou.com/',
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Mineradio/1.0',
+        },
+        cookie: session,
+        clearDefaultParams: true,
+        notSign: true,
+      });
+    } catch (searchError) {
+      const lyric = await getLegacyLyrics().catch(() => '');
+      if (lyric) {
+        return {
+          ok: true,
+          loggedIn: true,
+          lyric,
+          source: 'kugou-lrc',
+          candidate: { id: '', hash, duration },
+        };
+      }
+      throw searchError;
+    }
+    const candidates = Array.isArray(searchBody && searchBody.candidates)
+      ? searchBody.candidates
+      : (Array.isArray(searchBody && searchBody.data && searchBody.data.candidates) ? searchBody.data.candidates : []);
+    if (!candidates.length) {
+      const lyric = await getLegacyLyrics().catch(() => '');
+      return lyric
+        ? { ok: true, loggedIn: true, lyric, source: 'kugou-lrc', candidate: { id: '', hash, duration } }
+        : { ok: true, loggedIn: true, lyric: '', error: 'KUGOU_LYRIC_NOT_FOUND' };
+    }
+    const exactHash = hash && candidates.find((item) => String(firstValue(item, ['hash', 'filehash'], '')).trim().toUpperCase() === hash);
+    const exactAudio = albumAudioId && candidates.find((item) => Number(firstValue(item, ['album_audio_id', 'audio_id'], 0)) === albumAudioId);
+    const candidate = exactHash || exactAudio || candidates[0];
+    const id = String(firstValue(candidate, ['id', 'lyric_id'], '') || '').trim();
+    const accesskey = String(firstValue(candidate, ['accesskey', 'access_key'], '') || '').trim();
+    if (!id || !accesskey) return { ok: true, loggedIn: true, lyric: '', error: 'KUGOU_LYRIC_ACCESS_EMPTY' };
+    const downloadParams = {
+      ver: 1,
+      client: 'android',
+      id,
+      accesskey,
+      fmt: 'lrc',
+      charset: 'utf8',
+    };
+    let downloadBody;
+    try {
+      downloadBody = await request({
+        baseURL: 'https://lyrics.kugou.com',
+        url: '/download',
+        params: downloadParams,
+        cookie: session,
+      });
+    } catch (signedError) {
+      try {
+        downloadBody = await request({
+          baseURL: 'https://lyrics.kugou.com',
+          url: '/download',
+          params: Object.assign({}, downloadParams, { client: 'pc' }),
+          headers: {
+            Referer: 'https://www.kugou.com/',
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Mineradio/1.0',
+          },
+          clearDefaultParams: true,
+          notSign: true,
+        });
+      } catch (_unsignedError) {
+        throw signedError;
+      }
+    }
+    if (!downloadBody || !downloadBody.content) {
+      downloadBody = await request({
+        baseURL: 'https://lyrics.kugou.com',
+        url: '/download',
+        params: Object.assign({}, downloadParams, { client: 'pc' }),
+        headers: {
+          Referer: 'https://www.kugou.com/',
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Mineradio/1.0',
+        },
+        clearDefaultParams: true,
+        notSign: true,
+      });
+    }
+    let lyric = '';
+    try {
+      lyric = Buffer.from(String(downloadBody && downloadBody.content || ''), 'base64').toString('utf8').replace(/^\uFEFF/, '').trim();
+    } catch (_error) {
+      lyric = '';
+    }
+    return {
+      ok: true,
+      loggedIn: true,
+      lyric,
+      source: lyric ? 'kugou-lrc' : 'none',
+      candidate: {
+        id,
+        hash: String(firstValue(candidate, ['hash', 'filehash'], hash) || hash),
+        duration: Number(firstValue(candidate, ['duration'], duration)) || duration,
+      },
+    };
+  }
+
+  async function startLogin() {
+    const body = await request({
+      baseURL: 'https://login-user.kugou.com',
+      url: '/v2/qrcode',
+      params: {
+        appid: KUGOU_WEB_APP_ID,
+        type: 1,
+        plat: 4,
+        qrcode_txt: `https://h5.kugou.com/apps/loginQRCode/html/index.html?appid=${KUGOU_APP_ID}&`,
+        srcappid: KUGOU_SOURCE_APP_ID,
+      },
+      encryptType: 'web',
+    });
+    const data = body && body.data || {};
+    const key = String(data.qrcode || '');
+    if (!key) throw new Error('KUGOU_QR_KEY_EMPTY');
+    pendingLogin = { key, createdAt: Date.now() };
+    return {
+      ok: true,
+      image: String(data.qrcode_img || ''),
+      loginUrl: `https://h5.kugou.com/apps/loginQRCode/html/index.html?qrcode=${encodeURIComponent(key)}`,
+      expiresIn: Math.round(KUGOU_LOGIN_MAX_AGE_MS / 1000),
+    };
+  }
+
+  async function checkLogin() {
+    if (!pendingLogin) return { ok: false, status: 'missing', message: '请先刷新登录二维码' };
+    if (Date.now() - pendingLogin.createdAt > KUGOU_LOGIN_MAX_AGE_MS) {
+      pendingLogin = null;
+      return { ok: true, status: 'expired', message: '二维码已过期，请刷新' };
+    }
+    const body = await request({
+      baseURL: 'https://login-user.kugou.com',
+      url: '/v2/get_userinfo_qrcode',
+      params: {
+        plat: 4,
+        appid: KUGOU_APP_ID,
+        srcappid: KUGOU_SOURCE_APP_ID,
+        qrcode: pendingLogin.key,
+      },
+      encryptType: 'web',
+    });
+    const data = body && body.data || {};
+    const status = Number(data.status);
+    if (status === 0) {
+      pendingLogin = null;
+      return { ok: true, status: 'expired', message: '二维码已过期，请刷新' };
+    }
+    if (status === 1) return { ok: true, status: 'waiting', message: '请使用酷狗音乐 App 扫码' };
+    if (status === 2) return { ok: true, status: 'confirming', message: '已扫码，请在手机上确认登录' };
+    if (status !== 4) return { ok: true, status: 'waiting', message: '等待酷狗确认登录' };
+    const token = String(data.token || '');
+    const userid = String(data.userid || '');
+    if (!token || !userid) throw new Error('KUGOU_LOGIN_SESSION_EMPTY');
+    const session = {
+      token,
+      userid,
+      nickname: String(firstValue(data, ['nickname', 'username', 'user_name', 'nick_name'], '') || ''),
+      avatar: imageUrl(firstValue(data, ['pic', 'avatar', 'user_pic'], ''), 180),
+      updatedAt: Date.now(),
+    };
+    const persistent = writeSession(session);
+    pendingLogin = null;
+    return Object.assign({ status: 'authorized', message: '酷狗登录成功' }, sessionPublicView(session, persistent));
+  }
+
+  async function getPlaylists() {
+    const session = readSession();
+    if (!session) return { ok: false, loggedIn: false, error: 'KUGOU_NOT_LOGGED_IN' };
+    const pageSize = 100;
+    const collected = [];
+    let total = 0;
+    for (let page = 1; page <= KUGOU_MAX_PLAYLIST_PAGES; page += 1) {
+      const body = await request({
+        url: '/v7/get_all_list',
+        method: 'POST',
+        params: { plat: 1, userid: Number(session.userid), token: session.token },
+        data: {
+          userid: Number(session.userid),
+          token: session.token,
+          total_ver: 979,
+          type: 2,
+          page,
+          pagesize: pageSize,
+        },
+        headers: { 'x-router': 'cloudlist.service.kugou.com' },
+      });
+      const data = body && body.data || {};
+      total = Math.max(total, Number(firstValue(data, ['total', 'count', 'total_count'], 0)) || 0);
+      const pageItems = [];
+      collectPlaylistCandidates(data, session.userid, pageItems);
+      collected.push(...pageItems);
+      if (!pageItems.length || pageItems.length < pageSize || (total && collected.length >= total)) break;
+    }
+    const seen = new Set();
+    const playlists = collected.filter((playlist) => {
+      const key = `${playlist.globalId || ''}:${playlist.listId || ''}:${playlist.name}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+    return { ok: true, loggedIn: true, playlists, total: total || playlists.length, syncedAt: Date.now() };
+  }
+
+  async function getPlaylistTracks(playlist) {
+    const session = readSession();
+    if (!session) return { ok: false, loggedIn: false, error: 'KUGOU_NOT_LOGGED_IN' };
+    const globalId = String(playlist && (playlist.globalId || playlist.id) || '');
+    const listId = String(playlist && playlist.listId || '');
+    if (!globalId && !listId) return { ok: false, error: 'KUGOU_PLAYLIST_ID_EMPTY' };
+    const pageSize = 100;
+    const tracks = [];
+    let total = 0;
+    for (let page = 1; page <= KUGOU_MAX_TRACK_PAGES; page += 1) {
+      let body;
+      if (globalId && globalId.includes('collection_')) {
+        body = await request({
+          url: '/pubsongs/v2/get_other_list_file_nofilt',
+          params: {
+            area_code: 1,
+            begin_idx: (page - 1) * pageSize,
+            plat: 1,
+            type: 1,
+            mode: 1,
+            personal_switch: 1,
+            extend_fields: 'abtags,hot_cmt,popularization',
+            pagesize: pageSize,
+            global_collection_id: globalId,
+            token: session.token,
+            userid: Number(session.userid),
+          },
+        });
+      } else {
+        body = await request({
+          url: '/v4/get_list_all_file',
+          method: 'POST',
+          data: {
+            listid: listId || globalId,
+            userid: Number(session.userid),
+            area_code: 1,
+            show_relate_goods: 0,
+            pagesize: pageSize,
+            allplatform: 1,
+            show_cover: 1,
+            type: 0,
+            token: session.token,
+            page,
+          },
+          headers: { 'x-router': 'cloudlist.service.kugou.com' },
+        });
+      }
+      const data = body && body.data || {};
+      const rows = Array.isArray(data.songs) ? data.songs
+        : Array.isArray(data.info) ? data.info
+          : Array.isArray(data.list) ? data.list
+            : [];
+      total = Math.max(total, Number(firstValue(data, ['count', 'total', 'total_count'], 0)) || 0);
+      rows.forEach((row) => {
+        const track = normalizeTrack(row);
+        if (track) tracks.push(track);
+      });
+      if (!rows.length || rows.length < pageSize || (total && tracks.length >= total)) break;
+    }
+    const seen = new Set();
+    const deduped = tracks.filter((track) => {
+      const key = track.hash || `${track.name}\n${track.artist}`.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+    return { ok: true, loggedIn: true, tracks: deduped, total: total || deduped.length };
+  }
+
+  return {
+    getStatus: async () => sessionPublicView(readSession(), encryptionAvailable()),
+    startLogin,
+    checkLogin,
+    getPlaylists,
+    getPlaylistTracks,
+    searchTracks,
+    getStreamUrl,
+    getLyrics,
+    logout: async () => {
+      clearSession();
+      return { ok: true, loggedIn: false };
+    },
+  };
+}
+
+module.exports = {
+  createKugouSync,
+  __test: Object.freeze({
+    searchTrackIdentityScore,
+    streamIdentityMatches,
+    stripArtistPrefixFromTitle,
+    trackTitleBase,
+    trackVersionSignalsMatch,
+  }),
+};

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,10 +1,11 @@
-const { app, BrowserWindow, ipcMain, shell, screen, powerMonitor, globalShortcut, dialog, Tray, Menu } = require('electron');
+const { app, BrowserWindow, ipcMain, shell, screen, powerMonitor, globalShortcut, dialog, Tray, Menu, safeStorage, net: electronNet } = require('electron');
 const net = require('net');
 const path = require('path');
 const fs = require('fs');
 const { pathToFileURL } = require('url');
 const crypto = require('crypto');
 const { execFile, spawn } = require('child_process');
+const { createKugouSync } = require('./kugou-sync');
 
 let mainWindow = null;
 let localServer = null;
@@ -31,6 +32,8 @@ let miniPlayerUserMovePending = false;
 let miniPlayerLastSentState = null;
 let miniPlayerRecoveryTimer = null;
 let miniPlayerRecreateTimer = null;
+let miniPlayerDismissTimer = null;
+let miniPlayerAutoDismissed = false;
 const miniPlayerUserBoundsByMode = { standard: null, compact: null };
 const miniPlayerSavedBoundsSignatures = { standard: '', compact: '' };
 const miniPlayerProgrammaticCloseWindows = new WeakSet();
@@ -50,6 +53,7 @@ let mainWindowStateTimer = null;
 let tray = null;
 let closeToTrayEnabled = true;
 let appQuitting = false;
+let kugouSync = null;
 const registeredGlobalHotkeys = new Map();
 const authorizedLocalMusicRoots = new Set();
 
@@ -64,6 +68,7 @@ const COMPACT_MINI_PLAYER_WIDTH = 268;
 const COMPACT_MINI_PLAYER_HEIGHT = 58;
 const MINI_PLAYER_MARGIN = 14;
 const MINI_PLAYER_RECOVERY_INTERVAL = 5000;
+const MINI_PLAYER_PLAY_DISMISS_DELAY = 620;
 const APP_NAME = 'Mineradio';
 const APP_USER_MODEL_ID = 'com.mineradio.desktop';
 const APP_ICON_ICO = path.join(__dirname, '..', 'build', 'icon.ico');
@@ -82,6 +87,7 @@ const DESKTOP_UI_STATE_KEYS = new Set([
   'mineradio-free-camera-v1',
   'mineradio-local-library-folder-v1',
   'mineradio-playback-session-v1',
+  'mineradio-weather-city-v2',
   'mineradio-user-fx-archives-v1',
   'mineradio-hotkey-settings-v1',
   'mineradio-visual-guide-seen-v2',
@@ -660,6 +666,7 @@ function getSenderWindow(event) {
 function focusMainWindow() {
   if (!mainWindow || mainWindow.isDestroyed()) return false;
   miniPlayerActive = false;
+  resetMiniPlayerAutoDismiss();
   hideMiniPlayerWindow();
   if (mainWindow.isMinimized()) mainWindow.restore();
   if (!mainWindow.isVisible()) mainWindow.show();
@@ -1654,10 +1661,29 @@ function shouldShowMiniPlayer() {
   return !!(
     miniPlayerEnabled
     && miniPlayerActive
+    && !miniPlayerAutoDismissed
     && mainWindow
     && !mainWindow.isDestroyed()
     && (mainWindow.isMinimized() || !mainWindow.isVisible())
   );
+}
+
+function resetMiniPlayerAutoDismiss() {
+  miniPlayerAutoDismissed = false;
+  if (!miniPlayerDismissTimer) return;
+  clearTimeout(miniPlayerDismissTimer);
+  miniPlayerDismissTimer = null;
+}
+
+function dismissMiniPlayerAfterPlay() {
+  if (miniPlayerDismissTimer) clearTimeout(miniPlayerDismissTimer);
+  miniPlayerDismissTimer = setTimeout(() => {
+    miniPlayerDismissTimer = null;
+    if (!miniPlayerActive || !mainWindow || mainWindow.isDestroyed()) return;
+    miniPlayerAutoDismissed = true;
+    hideMiniPlayerWindow();
+  }, MINI_PLAYER_PLAY_DISMISS_DELAY);
+  if (typeof miniPlayerDismissTimer.unref === 'function') miniPlayerDismissTimer.unref();
 }
 
 function stopMiniPlayerRecoveryTimer() {
@@ -1814,7 +1840,11 @@ function createMiniPlayerWindow() {
   win.on('close', (event) => {
     if (appQuitting || miniPlayerProgrammaticCloseWindows.has(win)) return;
     event.preventDefault();
-    focusMainWindow();
+    miniPlayerActive = false;
+    miniPlayerAutoDismissed = true;
+    setImmediate(() => {
+      if (miniPlayerWindow === win) closeMiniPlayerWindow();
+    });
   });
   win.on('closed', () => {
     const wasCurrent = miniPlayerWindow === win;
@@ -1879,6 +1909,7 @@ function closeMiniPlayerWindow() {
 
 function setMiniPlayerEnabled(enabled) {
   miniPlayerEnabled = !!enabled;
+  resetMiniPlayerAutoDismiss();
   writeDesktopShellSettings({ miniPlayer: miniPlayerEnabled });
   if (miniPlayerEnabled) {
     if (mainWindow && !mainWindow.isDestroyed() && (mainWindow.isMinimized() || !mainWindow.isVisible())) miniPlayerActive = true;
@@ -1911,6 +1942,40 @@ function closeOverlayWindows() {
   closeMiniPlayerWindow();
 }
 
+function getKugouSync() {
+  if (!kugouSync) {
+    kugouSync = createKugouSync({
+      fetchImpl: (url, options) => electronNet.fetch(url, options),
+      userDataPath: app.getPath('userData'),
+      safeStorage,
+    });
+  }
+  return kugouSync;
+}
+
+function isMainRendererEvent(event) {
+  return !!(mainWindow && !mainWindow.isDestroyed() && event && event.sender === mainWindow.webContents);
+}
+
+async function runKugouIpc(event, operation) {
+  if (!isMainRendererEvent(event)) return { ok: false, error: 'KUGOU_INVALID_SENDER' };
+  try {
+    return await operation(getKugouSync());
+  } catch (error) {
+    const code = String(error && error.code || error && error.message || 'KUGOU_REQUEST_FAILED');
+    const sessionExpired = ['20010', '20011', '20017', '10009'].includes(code);
+    const actualFileName = code === 'KUGOU_STREAM_IDENTITY_MISMATCH'
+      ? String(error && error.actualFileName || '').trim().slice(0, 300)
+      : '';
+    return {
+      ok: false,
+      error: sessionExpired ? 'KUGOU_SESSION_EXPIRED' : code.slice(0, 160),
+      loggedIn: sessionExpired ? false : undefined,
+      actualFileName,
+    };
+  }
+}
+
 ipcMain.handle('desktop-window-minimize', (event) => {
   getSenderWindow(event)?.minimize();
 });
@@ -1933,6 +1998,97 @@ ipcMain.handle('desktop-window-get-state', (event) => {
 
 ipcMain.handle('desktop-window-close', (event) => {
   getSenderWindow(event)?.close();
+});
+
+ipcMain.handle('mineradio-moji-weather', async (event, city) => {
+  if (!isMainRendererEvent(event)) return { ok: false, error: 'WEATHER_INVALID_SENDER' };
+  const safeCity = String(city || '').trim().slice(0, 80);
+  if (!safeCity) return { ok: false, error: 'WEATHER_CITY_EMPTY' };
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 12000);
+  try {
+    const url = new URL('https://api.xcvts.cn/api/weather/mojicax');
+    url.searchParams.set('city', safeCity);
+    url.searchParams.set('n', '1');
+    url.searchParams.set('num', '20');
+    const response = await electronNet.fetch(url.toString(), {
+      signal: controller.signal,
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) return { ok: false, error: `WEATHER_HTTP_${response.status}` };
+    const text = await response.text();
+    if (text.length > 2 * 1024 * 1024) return { ok: false, error: 'WEATHER_RESPONSE_TOO_LARGE' };
+    return { ok: true, body: JSON.parse(text) };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error && error.name === 'AbortError' ? 'WEATHER_TIMEOUT' : 'WEATHER_REQUEST_FAILED',
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+});
+
+ipcMain.handle('mineradio-kugou-status', (event) => {
+  return runKugouIpc(event, (service) => service.getStatus());
+});
+
+ipcMain.handle('mineradio-kugou-login-start', (event) => {
+  return runKugouIpc(event, (service) => service.startLogin());
+});
+
+ipcMain.handle('mineradio-kugou-login-check', (event) => {
+  return runKugouIpc(event, (service) => service.checkLogin());
+});
+
+ipcMain.handle('mineradio-kugou-playlists', (event) => {
+  return runKugouIpc(event, (service) => service.getPlaylists());
+});
+
+ipcMain.handle('mineradio-kugou-playlist-tracks', (event, playlist) => {
+  const safePlaylist = {
+    id: String(playlist && playlist.id || '').slice(0, 200),
+    globalId: String(playlist && playlist.globalId || '').slice(0, 200),
+    listId: String(playlist && playlist.listId || '').slice(0, 80),
+  };
+  return runKugouIpc(event, (service) => service.getPlaylistTracks(safePlaylist));
+});
+
+ipcMain.handle('mineradio-kugou-search', (event, input) => {
+  const safeInput = {
+    query: String(input && input.query || '').trim().slice(0, 120),
+    page: Math.max(1, Math.min(20, Number(input && input.page) || 1)),
+    pageSize: Math.max(1, Math.min(30, Number(input && input.pageSize) || 20)),
+  };
+  return runKugouIpc(event, (service) => service.searchTracks(safeInput));
+});
+
+ipcMain.handle('mineradio-kugou-stream-url', (event, track) => {
+  const requestedQuality = String(track && track.quality || 'auto').toLowerCase();
+  const safeTrack = {
+    hash: String(track && track.hash || '').trim().slice(0, 64),
+    albumId: String(track && track.albumId || '0').replace(/[^0-9]/g, '').slice(0, 20) || '0',
+    albumAudioId: String(track && track.albumAudioId || '0').replace(/[^0-9]/g, '').slice(0, 20) || '0',
+    name: String(track && track.name || '').trim().slice(0, 300),
+    artist: String(track && track.artist || '').trim().slice(0, 300),
+    quality: ['auto', 'jymaster', 'hires', 'lossless', 'exhigh', 'standard'].includes(requestedQuality) ? requestedQuality : 'auto',
+  };
+  return runKugouIpc(event, (service) => service.getStreamUrl(safeTrack));
+});
+
+ipcMain.handle('mineradio-kugou-lyrics', (event, track) => {
+  const safeTrack = {
+    hash: String(track && track.hash || '').trim().slice(0, 64),
+    albumAudioId: String(track && track.albumAudioId || '0').replace(/[^0-9]/g, '').slice(0, 20) || '0',
+    duration: Math.max(0, Math.min(86400, Number(track && track.duration) || 0)),
+    name: String(track && track.name || '').trim().slice(0, 300),
+    artist: String(track && track.artist || '').trim().slice(0, 300),
+  };
+  return runKugouIpc(event, (service) => service.getLyrics(safeTrack));
+});
+
+ipcMain.handle('mineradio-kugou-logout', (event) => {
+  return runKugouIpc(event, (service) => service.logout());
 });
 
 ipcMain.handle('mineradio-tray-get-settings', () => {
@@ -1983,10 +2139,28 @@ ipcMain.handle('mineradio-mini-player-command', (event, action) => {
   }
   const command = String(action || '');
   if (command === 'restore') return { ok: focusMainWindow() };
+  if (command === 'close') {
+    miniPlayerActive = false;
+    miniPlayerAutoDismissed = true;
+    setImmediate(closeMiniPlayerWindow);
+    return { ok: true, closed: true };
+  }
   if (!['toggle-play', 'previous', 'next'].includes(command)) return { ok: false, error: 'MINI_PLAYER_INVALID_COMMAND' };
   if (!mainWindow || mainWindow.isDestroyed()) return { ok: false, error: 'MAIN_WINDOW_UNAVAILABLE' };
+  const wasPlaying = !!miniPlayerState.playing;
+  const expectedPlaying = command === 'toggle-play' ? !wasPlaying : wasPlaying;
+  if (command === 'toggle-play') {
+    miniPlayerState = { ...miniPlayerState, playing: expectedPlaying };
+    sendMiniPlayerState(true);
+    if (expectedPlaying) dismissMiniPlayerAfterPlay();
+    else resetMiniPlayerAutoDismiss();
+  }
   mainWindow.webContents.send('mineradio-mini-player-command', { action: command });
-  return { ok: true };
+  return {
+    ok: true,
+    expectedPlaying,
+    dismissAfterMs: command === 'toggle-play' && expectedPlaying ? MINI_PLAYER_PLAY_DISMISS_DELAY : 0,
+  };
 });
 
 ipcMain.handle('mineradio-hotkeys-configure-global', (_event, bindings) => {
@@ -2292,12 +2466,14 @@ async function createWindow() {
   mainWindow.on('maximize', () => sendWindowState(mainWindow));
   mainWindow.on('unmaximize', () => sendWindowState(mainWindow));
   mainWindow.on('minimize', () => {
+    resetMiniPlayerAutoDismiss();
     miniPlayerActive = true;
     sendWindowState(mainWindow);
     showMiniPlayerWindow();
   });
   mainWindow.on('restore', () => {
     miniPlayerActive = false;
+    resetMiniPlayerAutoDismiss();
     hideMiniPlayerWindow();
     sendWindowState(mainWindow);
   });
@@ -2320,6 +2496,7 @@ async function createWindow() {
   mainWindow.on('close', (event) => {
     if (!appQuitting && (closeToTrayEnabled || miniPlayerEnabled)) {
       event.preventDefault();
+      resetMiniPlayerAutoDismiss();
       miniPlayerActive = miniPlayerEnabled;
       mainWindow.hide();
       if (miniPlayerActive) showMiniPlayerWindow();
@@ -2332,6 +2509,7 @@ async function createWindow() {
       mainWindowStateTimer = null;
     }
     closeOverlayWindows();
+    resetMiniPlayerAutoDismiss();
     miniPlayerActive = false;
     mainWindow = null;
   });

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -12,6 +12,7 @@ const PERSISTENT_UI_STATE_KEYS = [
   'mineradio-free-camera-v1',
   'mineradio-local-library-folder-v1',
   'mineradio-playback-session-v1',
+  'mineradio-weather-city-v2',
   'mineradio-user-fx-archives-v1',
   'mineradio-hotkey-settings-v1',
   'mineradio-visual-guide-seen-v2',
@@ -56,6 +57,20 @@ contextBridge.exposeInMainWorld('desktopWindow', {
   refreshLocalMusicFiles: (folderPath, files) => ipcRenderer.invoke('mineradio-local-music-refresh-entries', folderPath, files || []),
   readLocalFileRange: (filePath, start, end) => ipcRenderer.invoke('mineradio-local-file-read-range', filePath, start, end),
   readLocalFileDataUrl: (filePath) => ipcRenderer.invoke('mineradio-local-file-read-data-url', filePath),
+  getKugouStatus: () => ipcRenderer.invoke('mineradio-kugou-status'),
+  startKugouLogin: () => ipcRenderer.invoke('mineradio-kugou-login-start'),
+  checkKugouLogin: () => ipcRenderer.invoke('mineradio-kugou-login-check'),
+  getKugouPlaylists: () => ipcRenderer.invoke('mineradio-kugou-playlists'),
+  getKugouPlaylistTracks: (playlist) => ipcRenderer.invoke('mineradio-kugou-playlist-tracks', playlist || {}),
+  searchKugouTracks: (query, options) => ipcRenderer.invoke('mineradio-kugou-search', {
+    query: String(query || ''),
+    page: Number(options && options.page) || 1,
+    pageSize: Number(options && options.pageSize) || 20,
+  }),
+  getKugouStreamUrl: (track) => ipcRenderer.invoke('mineradio-kugou-stream-url', track || {}),
+  getKugouLyrics: (track) => ipcRenderer.invoke('mineradio-kugou-lyrics', track || {}),
+  logoutKugou: () => ipcRenderer.invoke('mineradio-kugou-logout'),
+  fetchMojiWeather: (city) => ipcRenderer.invoke('mineradio-moji-weather', String(city || '')),
   onGlobalHotkey: (callback) => {
     if (typeof callback !== 'function') return () => {};
     const listener = (_event, payload) => callback(payload || {});

--- a/public/index.html
+++ b/public/index.html
@@ -168,23 +168,16 @@ body.splash-active.splash-revealing #top-right{opacity:1;transition:opacity 1100
 .search-mode-tabs button{height:24px;padding:0 12px;border:0;border-radius:999px;background:transparent;color:rgba(255,255,255,.42);font-family:inherit;font-size:10.5px;font-weight:650;letter-spacing:.7px;cursor:pointer;transition:background .22s,color .22s,box-shadow .22s,transform .22s}
 .search-mode-tabs button:hover{color:rgba(255,255,255,.78)}
 .search-mode-tabs button.active{color:#eafffb;background:rgba(0,245,212,.11);box-shadow:inset 0 0 0 1px rgba(0,245,212,.22),0 8px 24px rgba(0,245,212,.055)}
-body.local-only-mode #user-btn,
 body.local-only-mode #user-capsule-hide-btn,
-body.local-only-mode #search-mode-tabs,
-body.local-only-mode #tab-pl,
 body.local-only-mode #tab-podcast,
-body.local-only-mode #pl-pane,
 body.local-only-mode #podcast-pane,
 body.local-only-mode #heart-btn,
 body.local-only-mode #collect-btn,
 body.local-only-mode #quality-control,
 body.local-only-mode #trial-banner,
-body.local-only-mode #login-modal,
-body.local-only-mode #user-modal,
 body.local-only-mode #login-guide-canvas,
 body.local-only-mode .login-link,
 body.local-only-mode #search-results .song-action-btn{display:none!important}
-body.local-only-mode #queue-pane{display:block!important}
 body.local-only-mode .tag-source.local{color:#e6edf3;border-color:rgba(157,184,207,.34);background:rgba(157,184,207,.12)}
 body.empty-home-active.diy-mode #search-area:not(.has-results) #search-mode-tabs{display:none}
 #search-results{margin-top:8px;background:rgba(12,12,18,0.55);border:1px solid rgba(255,255,255,0.06);border-radius:14px;max-height:360px;overflow-y:auto;overscroll-behavior:contain;backdrop-filter:blur(40px) saturate(1.4);-webkit-backdrop-filter:blur(40px) saturate(1.4);display:none}
@@ -215,6 +208,12 @@ body.empty-home-active.diy-mode #search-area:not(.has-results) #search-mode-tabs
 .tag-source.qq{color:#f0ffc8;border-color:rgba(191,214,107,.30);background:rgba(191,214,107,.075)}
 .search-result.qq-source:hover{background:rgba(191,214,107,.052)}
 .search-result.netease-source:hover{background:rgba(217,91,103,.045)}
+.tag-source.kugou{color:#bafff6;border-color:rgba(0,245,212,.32);background:rgba(0,245,212,.085)}
+.search-result.kugou-source:hover{background:rgba(0,245,212,.06)}
+.search-online-note{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:11px 14px;border-top:1px solid rgba(255,255,255,.045);background:rgba(0,245,212,.035);color:rgba(255,255,255,.48);font-size:10.5px;line-height:1.45}
+.search-online-note b{color:#a9fff3;font-size:10px;letter-spacing:.08em}
+.search-online-note button{height:26px;padding:0 10px;border:1px solid rgba(0,245,212,.24);border-radius:999px;background:rgba(0,245,212,.08);color:#cafff8;font:inherit;cursor:pointer;white-space:nowrap}
+.search-online-note button:hover{border-color:rgba(0,245,212,.48);background:rgba(0,245,212,.15);color:#fff}
 .podcast-result-head{display:flex;align-items:center;gap:10px;padding:11px 13px 9px;border-bottom:1px solid rgba(255,255,255,.04);background:rgba(255,255,255,.025)}
 .podcast-result-head img{width:40px;height:40px;border-radius:7px;object-fit:cover;background:rgba(255,255,255,.05);flex-shrink:0}
 .podcast-back-btn{width:28px;height:28px;border-radius:50%;border:1px solid rgba(255,255,255,.10);background:rgba(255,255,255,.045);color:rgba(255,255,255,.66);cursor:pointer;font-family:inherit;font-size:18px;line-height:1;display:flex;align-items:center;justify-content:center;transition:all .2s}
@@ -264,6 +263,29 @@ body.home-wallpaper-preview #canvas-container{filter:none}
 .home-hero-inner{position:relative;z-index:2;height:100%;display:grid;grid-template-columns:minmax(0,1.16fr) minmax(150px,.64fr);grid-template-rows:auto auto auto auto minmax(150px,1fr);column-gap:18px}
 .home-hero-inner.home-construction-inner{display:flex;flex-direction:column;justify-content:center;align-items:flex-start;gap:18px;padding:4px 2px;min-height:100%}
 .home-hero-inner.home-local-import-inner{display:flex;flex-direction:column;justify-content:center;align-items:center;gap:18px;padding:8px;min-height:100%;text-align:center}
+.home-hero-inner.home-now-inner{display:flex;flex-direction:column;justify-content:center;gap:0;padding:2px 4px;min-height:100%}
+.home-now-top{display:flex;align-items:flex-start;justify-content:space-between;gap:18px}
+.home-now-kicker{font-size:10px;font-weight:800;letter-spacing:.18em;color:rgba(0,245,212,.72);text-transform:uppercase}
+.home-now-daypart{height:27px;padding:0 10px;border-radius:999px;border:1px solid rgba(255,255,255,.11);background:rgba(255,255,255,.05);display:inline-flex;align-items:center;font-size:10px;font-weight:760;letter-spacing:.12em;color:rgba(255,255,255,.68)}
+.home-clock-row{display:flex;align-items:baseline;gap:12px;margin-top:9px}
+.home-clock{font-variant-numeric:tabular-nums;font-size:clamp(62px,8.4vw,96px);font-weight:720;line-height:.9;letter-spacing:-.055em;color:rgba(255,255,255,.98);text-shadow:0 16px 46px rgba(0,0,0,.34)}
+.home-clock-date{margin-top:10px;font-size:13px;font-weight:620;letter-spacing:.04em;color:rgba(255,255,255,.54)}
+.home-weather-now{display:grid;grid-template-columns:54px minmax(0,1fr) auto;align-items:center;gap:14px;margin-top:22px;padding:15px 16px;border-radius:20px;border:1px solid rgba(255,255,255,.10);background:linear-gradient(135deg,rgba(255,255,255,.075),rgba(255,255,255,.028));box-shadow:inset 0 1px 0 rgba(255,255,255,.07),0 18px 50px rgba(0,0,0,.20)}
+.home-weather-icon{width:54px;height:54px;border-radius:17px;display:flex;align-items:center;justify-content:center;background:linear-gradient(145deg,rgba(0,245,212,.17),rgba(36,66,255,.13));box-shadow:inset 0 1px 0 rgba(255,255,255,.09);font-size:26px}
+.home-weather-copy{min-width:0}
+.home-weather-label{font-size:9px;font-weight:800;letter-spacing:.17em;text-transform:uppercase;color:rgba(0,245,212,.64)}
+.home-weather-title{margin-top:4px;font-size:15px;font-weight:760;color:rgba(255,255,255,.93);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.home-weather-sub{margin-top:4px;font-size:10.5px;line-height:1.42;color:rgba(255,255,255,.46)}
+.home-weather-actions{display:flex;flex-direction:column;align-items:stretch;gap:7px}
+.home-weather-action{height:31px;padding:0 12px;border-radius:999px;border:1px solid rgba(255,255,255,.11);background:rgba(255,255,255,.055);color:rgba(255,255,255,.78);font-family:inherit;font-size:10.5px;font-weight:720;cursor:pointer;white-space:nowrap;transition:transform .18s,border-color .18s,background .18s,color .18s}
+.home-weather-action:hover{transform:translateY(-1px);border-color:rgba(0,245,212,.35);background:rgba(0,245,212,.10);color:#fff}
+.home-weather-action.primary{border-color:rgba(0,245,212,.25);background:rgba(0,245,212,.085)}
+.home-weather-action[hidden]{display:none!important}
+.home-now-divider{height:1px;margin:21px 0 17px;background:linear-gradient(90deg,transparent,rgba(255,255,255,.12),transparent)}
+.home-now-local-label{margin-bottom:10px;font-size:9px;font-weight:780;letter-spacing:.16em;text-transform:uppercase;color:rgba(255,255,255,.32)}
+.home-now-inner .home-local-actions{width:100%;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}
+.home-now-inner .home-local-action{height:44px;border-radius:14px;font-size:12px}
+.home-now-inner .local-analysis-progress{width:100%;margin-top:10px}
 .home-local-actions{display:grid;grid-template-columns:repeat(2,minmax(150px,1fr));gap:14px;width:min(420px,100%)}
 .home-local-action{height:54px;border-radius:16px;border:1px solid rgba(255,255,255,.12);background:linear-gradient(145deg,rgba(255,255,255,.075),rgba(255,255,255,.035));color:rgba(255,255,255,.92);font-family:inherit;font-size:15px;font-weight:760;letter-spacing:0;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:9px;box-shadow:0 16px 44px rgba(0,0,0,.24),inset 0 1px 0 rgba(255,255,255,.10);transition:transform .2s,border-color .2s,background .2s,box-shadow .2s}
 .home-local-action:hover{transform:translateY(-2px);border-color:rgba(0,245,212,.42);background:linear-gradient(145deg,rgba(0,245,212,.12),rgba(255,255,255,.045));box-shadow:0 22px 58px rgba(0,0,0,.30),0 0 28px rgba(0,245,212,.10),inset 0 1px 0 rgba(255,255,255,.13)}
@@ -274,11 +296,12 @@ body.home-wallpaper-preview #canvas-container{filter:none}
 .local-analysis-progress-count{color:rgba(0,245,212,.88);font-weight:760}
 .local-analysis-progress-bar{height:5px;border-radius:999px;background:rgba(255,255,255,.10);overflow:hidden}
 .local-analysis-progress-fill{display:block;width:0%;height:100%;border-radius:inherit;background:linear-gradient(90deg,#00f5d4,#9db8cf,#f8f4ee);box-shadow:0 0 18px rgba(0,245,212,.26);transition:width .28s ease}
-html.local-only-mode #empty-home .empty-home-shell{grid-template-columns:minmax(280px,620px);justify-content:center}
+html.local-only-mode #empty-home .empty-home-shell{grid-template-columns:minmax(280px,760px);justify-content:center}
 html.local-only-mode #empty-home .home-hero{grid-row:auto;min-height:250px}
 html.local-only-mode #empty-home .home-grid,
 html.local-only-mode #empty-home .home-rail{display:none!important}
 @media (max-width:420px){.home-local-actions{grid-template-columns:1fr}.home-local-action{height:50px}}
+@media (max-width:620px){.home-weather-now{grid-template-columns:46px minmax(0,1fr);padding:13px}.home-weather-icon{width:46px;height:46px;border-radius:15px;font-size:22px}.home-weather-actions{grid-column:1 / -1;flex-direction:row}.home-weather-action{flex:1}.home-clock{font-size:62px}}
 .home-kicker{grid-column:1;font-size:10px;font-weight:780;letter-spacing:.18em;color:color-mix(in srgb,var(--home-accent) 62%,rgba(255,255,255,.36));text-transform:uppercase;margin-bottom:14px}
 .home-title{grid-column:1;font-size:clamp(34px,4.6vw,58px);line-height:.98;font-weight:760;letter-spacing:0;color:rgba(255,255,255,.98);max-width:380px;text-shadow:0 10px 36px rgba(0,0,0,.26)}
 .home-title.home-construction-title{max-width:620px;font-size:clamp(32px,4.5vw,64px);line-height:1.08}
@@ -869,6 +892,26 @@ body.login-guide-active #login-guide-canvas{opacity:1}
 .account-modal-actions{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:14px}
 .account-modal-actions .modal-btn{padding:8px 10px}
 .account-hint{margin-top:10px;font-size:11px;line-height:1.45;color:rgba(255,255,255,.38)}
+.kugou-modal{width:min(410px,92vw);max-width:min(410px,92vw);padding:28px}
+.kugou-modal-close{position:absolute;right:16px;top:14px;width:30px;height:30px;border:0;border-radius:9px;background:rgba(255,255,255,.045);color:rgba(255,255,255,.55);font:18px/1 inherit;cursor:pointer;transition:background .2s,color .2s,transform .2s}
+.kugou-modal-close:hover{background:rgba(255,255,255,.1);color:#fff;transform:rotate(5deg)}
+.kugou-brand{display:inline-flex;align-items:center;gap:8px;height:26px;padding:0 10px;margin-bottom:12px;border-radius:999px;border:1px solid rgba(0,245,212,.22);background:rgba(0,245,212,.07);color:#bafff6;font-size:10.5px;font-weight:750;letter-spacing:.09em}
+.kugou-brand-dot{width:7px;height:7px;border-radius:50%;background:#00f5d4;box-shadow:0 0 16px rgba(0,245,212,.8)}
+.kugou-qr-shell{position:relative;width:204px;height:204px;margin:4px auto 14px;padding:10px;border-radius:18px;background:#fff;box-shadow:0 18px 50px rgba(0,0,0,.42),0 0 0 1px rgba(0,245,212,.16)}
+#kugou-qr-img{display:block;width:184px;height:184px;border-radius:10px;object-fit:contain}
+.kugou-qr-placeholder{position:absolute;inset:10px;display:flex;align-items:center;justify-content:center;border-radius:10px;background:linear-gradient(135deg,#f3f5f5,#fff);color:#596164;font-size:11px;letter-spacing:.04em}
+.kugou-qr-shell.ready .kugou-qr-placeholder{display:none}
+#kugou-qr-status{min-height:19px;margin-bottom:8px;color:rgba(255,255,255,.62);font-size:12px;letter-spacing:.02em}
+#kugou-qr-status.scan{color:#7ee2a8}#kugou-qr-status.fail{color:#f08080}
+.kugou-security-note{margin:12px auto 0;max-width:330px;padding:10px 12px;border-radius:12px;background:rgba(255,255,255,.028);border:1px solid rgba(255,255,255,.06);font-size:10.5px;line-height:1.55;color:rgba(255,255,255,.38);text-align:left}
+.kugou-user-card{display:flex;align-items:center;gap:13px;margin:2px 0 16px;padding:14px;border:1px solid rgba(0,245,212,.13);border-radius:15px;background:linear-gradient(135deg,rgba(0,245,212,.07),rgba(255,255,255,.025));text-align:left}
+.kugou-user-avatar{width:48px;height:48px;flex:0 0 auto;border-radius:13px;object-fit:cover;background:rgba(255,255,255,.06);box-shadow:0 10px 30px rgba(0,0,0,.25)}
+.kugou-user-name{font-size:15px;font-weight:720;color:rgba(255,255,255,.94);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.kugou-user-id{margin-top:4px;font-size:10.5px;color:rgba(255,255,255,.38)}
+.kugou-sync-state{margin:0 0 12px;font-size:11.5px;color:rgba(255,255,255,.52)}
+.pl-kugou-badge{display:inline-flex;align-items:center;height:18px;margin-left:6px;padding:0 6px;border-radius:999px;border:1px solid rgba(0,245,212,.18);background:rgba(0,245,212,.07);color:#a9fff3;font-size:8.5px;font-weight:750;letter-spacing:.08em;vertical-align:1px}
+.pl-card.kugou-card{border-color:rgba(0,245,212,.08)}
+.pl-card.kugou-card:hover{border-color:rgba(0,245,212,.24)!important;background:rgba(0,245,212,.045)!important}
 .modal .btn-row{display:flex;gap:10px;justify-content:center;margin-top:16px}
 .dual-login-modal .btn-row{flex-wrap:wrap}
 .modal-btn{padding:8px 20px;font-size:12.5px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:rgba(255,255,255,0.05);color:#fff;cursor:pointer;letter-spacing:.5px;transition:all .2s;font-family:inherit}
@@ -1882,6 +1925,7 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
   .fx-slider{grid-template-columns:74px minmax(0,1fr) 40px 28px;gap:8px;padding:8px}
   .lyric-color-grid{grid-template-columns:repeat(3,minmax(0,1fr))}
 }
+body.local-only-mode.kugou-online-playing #quality-control{display:flex!important}
 </style>
 </head>
 <body>
@@ -1893,14 +1937,6 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
   </div>
   <div class="desktop-window-controls">
     <button id="visual-guide-btn" class="icon-btn" type="button" onclick="startVisualGuide({ manual: true })" title="查看使用引导" aria-label="查看使用引导">?</button>
-    <button id="update-entry" class="update-entry" type="button" onclick="openUpdatePanel()" title="发现新版本" aria-label="发现新版本">
-      <svg viewBox="0 0 24 24" aria-hidden="true">
-        <circle class="update-ring" cx="12" cy="12" r="8.8"></circle>
-        <circle id="update-progress-ring" class="update-progress-ring" cx="12" cy="12" r="8.8"></circle>
-        <path class="update-arrow" d="M12 16.5V7.5"></path>
-        <path class="update-arrow" d="M8.7 10.7 12 7.4l3.3 3.3"></path>
-      </svg>
-    </button>
     <button id="diy-mode-btn" class="desktop-mode-btn" type="button" onclick="toggleDiyMode()" title="开启 DIY 玩家模式" aria-label="开启 DIY 玩家模式" aria-pressed="false">DIY</button>
     <button class="desktop-window-btn" data-window-action="minimize" title="最小化" aria-label="最小化">
       <svg viewBox="0 0 16 16"><path d="M3 8h10"/></svg>
@@ -1946,10 +1982,10 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
   <div id="search-stack">
     <div id="search-box">
       <svg id="search-icon" width="17" height="17" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
-      <input id="search-input" type="text" placeholder="搜索本地歌曲、歌手、文件名..." autocomplete="off" spellcheck="false">
+      <input id="search-input" type="text" placeholder="搜索本地歌曲与酷狗曲库..." autocomplete="off" spellcheck="false">
     </div>
     <div id="search-mode-tabs" class="search-mode-tabs" role="tablist" aria-label="Search mode">
-      <button id="search-mode-song" class="active" type="button" onclick="setSearchMode('song')" aria-selected="true">Local</button>
+      <button id="search-mode-song" class="active" type="button" onclick="setSearchMode('song')" aria-selected="true">本地 + 酷狗</button>
     </div>
     <div id="search-results"></div>
   </div>
@@ -1973,23 +2009,25 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
 <section id="empty-home" aria-label="Mineradio home">
   <div class="empty-home-shell">
     <div class="home-hero">
-      <div class="home-hero-inner home-local-import-inner">
-        <div class="home-local-actions">
-          <button class="home-local-action" type="button" onclick="openLocalFolderImport()" aria-label="导入文件夹">
-            <svg fill="none" stroke="currentColor" stroke-width="1.9" viewBox="0 0 24 24"><path d="M3 7.5a2 2 0 0 1 2-2h4.2l2 2H19a2 2 0 0 1 2 2v7.8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M9 14h6"/><path d="M12 11v6"/></svg>
-            <span>导入文件夹</span>
-          </button>
-          <button class="home-local-action" type="button" onclick="document.getElementById('file-input').click()" aria-label="导入本地文件">
-            <svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
-            <span>本地文件</span>
-          </button>
+      <div class="home-hero-inner home-now-inner">
+        <div class="home-now-top">
+          <div class="home-now-kicker">NOW · LOCAL TIME</div>
+          <div class="home-now-daypart" id="home-daypart">本地时段</div>
         </div>
-        <div id="local-analysis-progress" class="local-analysis-progress" hidden>
-          <div class="local-analysis-progress-head">
-            <span id="local-analysis-progress-text">后台加载准备中</span>
-            <span id="local-analysis-progress-count" class="local-analysis-progress-count">0%</span>
+        <div class="home-clock-row">
+          <div class="home-clock" id="home-clock">--:--</div>
+        </div>
+        <div class="home-clock-date" id="home-clock-date">正在读取本地时间</div>
+        <div class="home-weather-now" id="home-weather-now">
+          <div class="home-weather-icon" id="home-weather-icon">◌</div>
+          <div class="home-weather-copy">
+            <div class="home-weather-label">MOJI WEATHER</div>
+            <div class="home-weather-title" id="home-weather-now-title">授权后显示城市天气</div>
+            <div class="home-weather-sub" id="home-weather-now-sub">首次授权定位后会记住城市，下次自动同步</div>
           </div>
-          <div class="local-analysis-progress-bar"><i id="local-analysis-progress-fill" class="local-analysis-progress-fill"></i></div>
+          <div class="home-weather-actions">
+            <button class="home-weather-action primary" id="home-weather-enable" type="button" onclick="enableLocalWeather(event)">授权定位</button>
+          </div>
         </div>
       </div>
     </div>
@@ -2054,7 +2092,7 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
   </button>
 </div>
 
-<button id="fx-fab" title="视觉控制台">
+<button id="fx-fab" type="button" onclick="toggleFxPanel()" title="视觉控制台" aria-label="视觉控制台">
   <svg width="21" height="21" fill="none" stroke="currentColor" stroke-width="1.9" viewBox="0 0 24 24"><path d="M4 7h8"/><path d="M16 7h4"/><circle cx="14" cy="7" r="2"/><path d="M4 17h4"/><path d="M12 17h8"/><circle cx="10" cy="17" r="2"/></svg>
 </button>
 <button id="fx-fab-hide-btn" type="button" onclick="toggleFxFabAutoHide(event)" title="自动隐藏视觉控制台">‹</button>
@@ -2062,7 +2100,7 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
 <!-- 控制台 (右侧贴边自动显示, 无关闭按钮) -->
 <div id="fx-panel">
   <div class="fx-head">
-    <div><div class="fx-title">视觉控制台</div><div class="fx-sub">MINERADIO VISUALS · 鼠标移开自动隐藏</div></div>
+    <div><div class="fx-title">DIY 视觉控制台</div><div class="fx-sub">MINERADIO VISUALS · 点击固定 · 再点收起</div></div>
   </div>
 
   <div class="fx-section-label">视觉预设</div>
@@ -2348,7 +2386,7 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
   </div>
   <div class="panel-tabs">
     <button id="tab-queue" class="panel-tab active" onclick="switchPlaylistTab('queue')">当前队列</button>
-    <button id="tab-pl" class="panel-tab" onclick="switchPlaylistTab('playlists')">本地库</button>
+    <button id="tab-pl" class="panel-tab" onclick="switchPlaylistTab('playlists')">歌单</button>
   </div>
   <div id="queue-pane">
     <div class="queue-toolbar">
@@ -2486,13 +2524,14 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
         </div>
       </div>
       <div id="quality-control" class="quality-control">
-        <button id="quality-btn" class="ctrl-btn quality-pill" onclick="toggleQualityPanel(event)" title="音质"><span id="quality-btn-label">臻音</span></button>
+        <button id="quality-btn" class="ctrl-btn quality-pill" onclick="toggleQualityPanel(event)" title="音质"><span id="quality-btn-label">自动</span></button>
         <div class="quality-popover" onclick="event.stopPropagation()">
-          <button class="quality-option svip-only" data-quality="jymaster" data-svip="1" onclick="setPlaybackQuality('jymaster')"><span>超清母带</span><small>SVIP / 最高规格</small></button>
-          <button class="quality-option" data-quality="hires" onclick="setPlaybackQuality('hires')"><span>高清臻音</span><small>默认 / 细节优先</small></button>
-          <button class="quality-option" data-quality="lossless" onclick="setPlaybackQuality('lossless')"><span>无损 SQ</span><small>FLAC 优先</small></button>
-          <button class="quality-option" data-quality="exhigh" onclick="setPlaybackQuality('exhigh')"><span>极高 HQ</span><small>320kbps</small></button>
-          <button class="quality-option" data-quality="standard" onclick="setPlaybackQuality('standard')"><span>标准</span><small>128kbps</small></button>
+          <button class="quality-option" data-quality="auto" onclick="setPlaybackQuality('auto')"><span>自动选择</span><small>优先最高可播放音质</small></button>
+          <button class="quality-option svip-only" data-quality="jymaster" data-svip="1" onclick="setPlaybackQuality('jymaster')"><span>蝰蛇超清</span><small>VIP / 纯净通透</small></button>
+          <button class="quality-option" data-quality="hires" onclick="setPlaybackQuality('hires')"><span>Hi-Res</span><small>高解析音源优先</small></button>
+          <button class="quality-option" data-quality="lossless" onclick="setPlaybackQuality('lossless')"><span>无损 FLAC</span><small>无损音源优先</small></button>
+          <button class="quality-option" data-quality="exhigh" onclick="setPlaybackQuality('exhigh')"><span>极高 HQ</span><small>320 kbps</small></button>
+          <button class="quality-option" data-quality="standard" onclick="setPlaybackQuality('standard')"><span>标准</span><small>128 kbps / 更省流量</small></button>
         </div>
       </div>
       <button id="heart-btn" class="ctrl-btn" onclick="toggleLikeCurrent()" title="红心喜欢"><svg class="heart-svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 21.45c-.32 0-.62-.12-.86-.34l-1.23-1.12C5.54 16.03 2.25 13.05 2.25 8.9 2.25 5.48 4.88 2.9 8.28 2.9c1.7 0 3.35.72 4.52 1.96C13.97 3.62 15.62 2.9 17.32 2.9c3.4 0 6.03 2.58 6.03 6 0 4.15-3.29 7.13-7.66 11.09l-1.23 1.12c-.24.22-.54.34-.86.34z"/></svg></button>
@@ -2532,8 +2571,41 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
 
 <canvas id="login-guide-canvas" aria-hidden="true"></canvas>
 
-<div id="login-modal" class="modal-mask"></div>
-<div id="user-modal" class="modal-mask"></div>
+<div id="login-modal" class="modal-mask">
+  <div class="modal kugou-modal" role="dialog" aria-modal="true" aria-labelledby="kugou-login-title">
+    <button class="kugou-modal-close" type="button" onclick="closeLoginModal()" aria-label="关闭">×</button>
+    <div class="kugou-brand"><span class="kugou-brand-dot"></span>KUGOU SYNC</div>
+    <h2 id="kugou-login-title">登录酷狗音乐</h2>
+    <div class="desc">使用酷狗音乐 App 扫码，把你的歌单同步到 Mineradio</div>
+    <div id="kugou-qr-shell" class="kugou-qr-shell">
+      <img id="kugou-qr-img" alt="酷狗音乐登录二维码">
+      <div class="kugou-qr-placeholder">正在连接酷狗登录服务…</div>
+    </div>
+    <div id="kugou-qr-status">准备登录二维码</div>
+    <div class="btn-row">
+      <button class="modal-btn primary" type="button" onclick="refreshQr()">刷新二维码</button>
+      <button class="modal-btn" type="button" onclick="closeLoginModal()">稍后再说</button>
+    </div>
+    <div class="kugou-security-note">密码和短信验证码只在酷狗官方 App 中完成。Mineradio 不读取密码，仅在本机加密保存登录会话，用于读取你的歌单。</div>
+  </div>
+</div>
+<div id="user-modal" class="modal-mask">
+  <div class="modal kugou-modal" role="dialog" aria-modal="true" aria-labelledby="kugou-user-title">
+    <button class="kugou-modal-close" type="button" onclick="closeUserModal()" aria-label="关闭">×</button>
+    <div class="kugou-brand"><span class="kugou-brand-dot"></span>KUGOU CONNECTED</div>
+    <h2 id="kugou-user-title">酷狗音乐账号</h2>
+    <div class="kugou-user-card">
+      <img id="kugou-user-avatar" class="kugou-user-avatar" alt="">
+      <div style="min-width:0;flex:1"><div id="kugou-user-name" class="kugou-user-name">酷狗用户</div><div id="kugou-user-id" class="kugou-user-id"></div></div>
+    </div>
+    <div id="kugou-sync-state" class="kugou-sync-state">歌单尚未同步</div>
+    <div class="btn-row">
+      <button class="modal-btn primary" type="button" onclick="syncKugouPlaylistsFromModal()">同步歌单</button>
+      <button class="modal-btn" type="button" onclick="logoutActiveAccount()">退出登录</button>
+    </div>
+    <div class="kugou-security-note">登录后可同步歌单并在线播放；会员曲目按你的酷狗账号权益播放，不抓取或下载音频。</div>
+  </div>
+</div>
 
 <!-- 封面裁剪模态 -->
 <div id="cover-crop-modal" class="modal-mask">
@@ -2720,6 +2792,7 @@ var LOCAL_SEARCH_RESULT_LIMIT = 80;
 var searchMode = 'song';
 var loginStatus = { loggedIn: false, vipType: 0, vipLevel: 'none', isVip: false, isSvip: false, vipLabel: '本地模式' };
 var loginStatusChecked = false, loginStatusCheckFailed = false;
+var kugouQrPollTimer = null, kugouQrCheckBusy = false, kugouPlaylistsLoading = false, kugouPlaylistsSyncedAt = 0;
 var volumeTween = null, trackSwitchToken = 0;
 var playIconUiState = { node: null, playing: null };
 var audioFadeTimer = null, audioElementFadeFrame = 0, audioFadeSerial = 0;
@@ -2749,6 +2822,7 @@ var LOCAL_LIBRARY_FOLDER_STORE_KEY = 'mineradio-local-library-folder-v1';
 var LOCAL_LIBRARY_SNAPSHOT_STORE_KEY = 'mineradio-local-library-snapshot-v1';
 var LOCAL_LIBRARY_INDEX_STORE_KEY = 'mineradio-local-library-index-v1';
 var PLAYBACK_SESSION_STORE_KEY = 'mineradio-playback-session-v1';
+var HOME_WEATHER_STORE_KEY = 'mineradio-weather-city-v2';
 var LOCAL_METADATA_TEXT_FIELDS = ['name', 'artist', 'album', 'albumArtist', 'trackNumber', 'year'];
 var LOCAL_METADATA_VALUE_FIELDS = ['duration', 'localFormat', 'localFileSize', 'localBitrateKbps'];
 var PERSISTENT_UI_STATE_KEYS = [
@@ -2763,6 +2837,7 @@ var PERSISTENT_UI_STATE_KEYS = [
   FREE_CAMERA_STORE_KEY,
   LOCAL_LIBRARY_FOLDER_STORE_KEY,
   PLAYBACK_SESSION_STORE_KEY,
+  HOME_WEATHER_STORE_KEY,
   'mineradio-user-fx-archives-v1',
   HOTKEY_SETTINGS_STORE_KEY,
   VISUAL_GUIDE_SEEN_STORE_KEY,
@@ -2909,6 +2984,9 @@ var emptyHomeActive = false;
 var homeForcedOpen = false;
 var homeSuppressed = false;
 var homeDiscoverState = { loading: false, loaded: false, loggedIn: false, mode: 'starter', songs: [], playlists: [], podcasts: [], error: '', updatedAt: 0 };
+var homeClockTimer = null;
+var homeWeatherRefreshTimer = null;
+var homeWeatherState = { status: 'idle', city: '', data: null, error: '', updatedAt: 0 };
 var homeVisualPresetActive = false;
 var homeVisualPrevPreset = 0;
 var HOME_LISTEN_STATS_KEY = 'mineradio-listen-stats-v1';
@@ -3185,6 +3263,9 @@ function applyDiyMode(on, opts) {
 }
 function toggleDiyMode() {
   applyDiyMode(!diyPlayerMode, { save: true, toast: true, animate: true });
+  if (diyPlayerMode) {
+    requestAnimationFrame(function(){ toggleFxPanel(true); });
+  }
   if (visualGuideActive) {
     visualGuideState.mode = diyPlayerMode ? 'diy' : 'simple';
     showVisualGuideStep(0);
@@ -10505,7 +10586,7 @@ function tickLyricsParticles() {
     if (stageLyrics.current || stageLyrics.currentText || (stageLyrics.outgoing && stageLyrics.outgoing.length)) clearStageLyrics();
     return;
   }
-  if (!playing || !audio || !lyricsLines.length) {
+  if (!audio || !lyricsLines.length) {
     if (stageLyrics.current) {
       stageLyrics.current.userData.state = 'out';
       stageLyrics.current.userData.age = 0;
@@ -16787,39 +16868,43 @@ function escHtml(s) {
 }
 function normalizePlaybackQuality(value) {
   value = String(value || '').toLowerCase();
+  if (value === 'auto' || value === 'best') return 'auto';
   if (value === 'jymaster' || value === 'master' || value === 'svip') return 'jymaster';
   if (value === 'hires' || value === 'hi-res' || value === 'highres' || value === 'highest') return 'hires';
   if (value === 'lossless' || value === 'flac' || value === 'sq') return 'lossless';
   if (value === 'exhigh' || value === 'high' || value === '320k' || value === 'hq') return 'exhigh';
   if (value === 'standard' || value === 'normal' || value === 'std') return 'standard';
-  return 'hires';
+  return 'auto';
 }
 function playbackQualityLabel(value) {
   value = normalizePlaybackQuality(value);
-  if (value === 'jymaster') return '超清母带';
-  if (value === 'hires') return '高清臻音';
-  if (value === 'lossless') return '无损';
-  if (value === 'exhigh') return '极高';
+  if (value === 'auto') return '自动选择';
+  if (value === 'jymaster') return '蝰蛇超清';
+  if (value === 'hires') return 'Hi-Res';
+  if (value === 'lossless') return '无损 FLAC';
+  if (value === 'exhigh') return '极高 HQ';
   if (value === 'standard') return '标准';
-  return '高清臻音';
+  return '自动选择';
 }
 function playbackQualityShortLabel(value) {
   value = normalizePlaybackQuality(value);
-  if (value === 'jymaster') return '母带';
-  if (value === 'hires') return '臻音';
+  if (value === 'auto') return '自动';
+  if (value === 'jymaster') return '蝰蛇';
+  if (value === 'hires') return 'Hi-Res';
   if (value === 'lossless') return 'SQ';
   if (value === 'exhigh') return 'HQ';
   if (value === 'standard') return 'STD';
-  return '臻音';
+  return '自动';
 }
 function playbackQualityRank(value) {
   value = normalizePlaybackQuality(value);
+  if (value === 'auto') return 6;
   if (value === 'jymaster') return 5;
   if (value === 'hires') return 4;
   if (value === 'lossless') return 3;
   if (value === 'exhigh') return 2;
   if (value === 'standard') return 1;
-  return 4;
+  return 6;
 }
 function playbackQualityWasDowngraded(requested, resolved) {
   return playbackQualityRank(resolved) < playbackQualityRank(requested);
@@ -16838,9 +16923,9 @@ function playbackResolvedQualityText(data) {
 }
 function readPlaybackQualityPreference() {
   try {
-    return normalizePlaybackQuality(localStorage.getItem(PLAYBACK_QUALITY_STORE_KEY) || 'hires');
+    return normalizePlaybackQuality(localStorage.getItem(PLAYBACK_QUALITY_STORE_KEY) || 'auto');
   } catch (e) {
-    return 'hires';
+    return 'auto';
   }
 }
 function savePlaybackQualityPreference() {
@@ -16851,28 +16936,38 @@ function updatePlaybackQualityUi() {
   var btn = document.getElementById('quality-btn');
   var displayQuality = playbackQuality;
   if (label) label.textContent = playbackQualityShortLabel(displayQuality);
-  if (btn) btn.title = '音质: 本地文件按原始编码播放';
+  var currentSong = currentIdx >= 0 && playQueue[currentIdx] ? playQueue[currentIdx] : null;
+  var kugouPlaying = !!(currentSong && currentSong.type === 'kugou');
+  if (btn) btn.title = kugouPlaying ? ('酷狗音质: ' + playbackQualityLabel(displayQuality)) : '本地文件按原始编码播放';
   document.querySelectorAll('.quality-option').forEach(function(option){
     var q = normalizePlaybackQuality(option.dataset.quality);
     option.classList.toggle('active', q === displayQuality);
     option.classList.remove('locked');
     option.disabled = false;
-    option.title = '本地文件按原始编码播放';
+    option.title = kugouPlaying ? ('切换到' + playbackQualityLabel(q)) : '酷狗在线播放时可选择';
   });
 }
 function setPlaybackQuality(value) {
   var next = normalizePlaybackQuality(value);
+  var previous = playbackQuality;
+  var wrap = document.getElementById('quality-control');
+  if (wrap) wrap.classList.remove('open');
+  if (next === previous) {
+    showToast('当前已是' + playbackQualityLabel(next));
+    return;
+  }
   playbackQuality = next;
   savePlaybackQualityPreference();
   updatePlaybackQualityUi();
-  var wrap = document.getElementById('quality-control');
-  if (wrap) wrap.classList.remove('open');
-  applyPlaybackQualityToCurrentTrack(next);
+  applyPlaybackQualityToCurrentTrack(next, previous);
 }
 function canReloadCurrentTrackForQuality() {
-  return false;
+  var song = currentIdx >= 0 && playQueue[currentIdx] ? playQueue[currentIdx] : null;
+  return !!(song && song.type === 'kugou');
 }
-function applyPlaybackQualityToCurrentTrack(nextQuality) {
+function applyPlaybackQualityToCurrentTrack(nextQuality, previousQuality) {
+  nextQuality = normalizePlaybackQuality(nextQuality || playbackQuality);
+  previousQuality = normalizePlaybackQuality(previousQuality || playbackQuality);
   var label = playbackQualityLabel(nextQuality || playbackQuality);
   if (!canReloadCurrentTrackForQuality()) {
     showToast('音质偏好: ' + label + ' · 下次播放生效');
@@ -16885,9 +16980,26 @@ function applyPlaybackQualityToCurrentTrack(nextQuality) {
     qualitySwitch: true,
     resumeAt: resumeAt,
     preserveHomeState: true,
+    propagateError: true,
   })).catch(function(e){
     console.warn('[QualitySwitch]', e);
-    showToast('音质切换失败，已保留偏好');
+    playbackQuality = previousQuality;
+    savePlaybackQualityPreference();
+    updatePlaybackQualityUi();
+    var previousLabel = playbackQualityLabel(previousQuality);
+    showToast('所选音质版本不一致，正在恢复' + previousLabel);
+    return Promise.resolve(playQueueAt(currentIdx, {
+      qualityOverride: previousQuality,
+      qualityRollback: true,
+      resumeAt: resumeAt,
+      preserveHomeState: true,
+      propagateError: true,
+    })).then(function(){
+      showToast('已恢复' + previousLabel + '并继续播放');
+    }).catch(function(rollbackError){
+      console.warn('[QualityRollback]', rollbackError);
+      showToast('音质切换失败，请重新点击播放');
+    });
   }).finally(forcePlaybackControlsInteractive);
 }
 function toggleQualityPanel(e) {
@@ -17342,6 +17454,238 @@ function homeToneForItem(item, index) {
  * @param {Array<object>} items Home 首屏卡片数据。
  * @returns {void}
  */
+function homeDaypart(hour) {
+  if (hour < 5) return { zh: '深夜', en: 'MIDNIGHT' };
+  if (hour < 8) return { zh: '清晨', en: 'EARLY AM' };
+  if (hour < 12) return { zh: '上午', en: 'MORNING' };
+  if (hour < 14) return { zh: '午间', en: 'NOON' };
+  if (hour < 18) return { zh: '下午', en: 'AFTERNOON' };
+  if (hour < 22) return { zh: '夜晚', en: 'EVENING' };
+  return { zh: '深夜', en: 'LATE NIGHT' };
+}
+function updateHomeClock() {
+  var now = new Date();
+  var clock = document.getElementById('home-clock');
+  var date = document.getElementById('home-clock-date');
+  var daypart = document.getElementById('home-daypart');
+  if (clock) clock.textContent = String(now.getHours()).padStart(2, '0') + ':' + String(now.getMinutes()).padStart(2, '0');
+  if (date) date.textContent = new Intl.DateTimeFormat('zh-CN', { year:'numeric', month:'long', day:'numeric', weekday:'long' }).format(now);
+  if (daypart) {
+    var part = homeDaypart(now.getHours());
+    daypart.textContent = part.zh + ' · ' + part.en;
+  }
+}
+function initHomeClock() {
+  updateHomeClock();
+  if (homeClockTimer) clearInterval(homeClockTimer);
+  homeClockTimer = setInterval(updateHomeClock, 30000);
+}
+function weatherIconForCondition(condition) {
+  condition = String(condition || '');
+  if (/雷/.test(condition)) return 'ϟ';
+  if (/雨/.test(condition)) return '☂';
+  if (/雪|冰/.test(condition)) return '❄';
+  if (/雾|霾|沙|尘/.test(condition)) return '≋';
+  if (/云|阴/.test(condition)) return '☁';
+  if (/晴/.test(condition)) return new Date().getHours() >= 19 || new Date().getHours() < 6 ? '☾' : '☀';
+  return '◌';
+}
+function readHomeWeatherCache() {
+  try {
+    var value = JSON.parse(localStorage.getItem(HOME_WEATHER_STORE_KEY) || 'null');
+    if (!value || !String(value.city || '').trim()) return null;
+    return {
+      city: String(value.city || '').trim().slice(0, 80),
+      data: value.data && typeof value.data === 'object' ? value.data : null,
+      updatedAt: Math.max(0, Number(value.updatedAt) || 0)
+    };
+  } catch (e) {
+    return null;
+  }
+}
+function saveHomeWeatherCache(city, data, updatedAt) {
+  city = String(city || '').trim().slice(0, 80);
+  if (!city) return;
+  setPersistentLocalStorageItem(HOME_WEATHER_STORE_KEY, JSON.stringify({
+    city: city,
+    data: data && typeof data === 'object' ? data : null,
+    updatedAt: Math.max(0, Number(updatedAt) || 0)
+  }));
+}
+function homeWeatherSyncLabel(updatedAt) {
+  if (!updatedAt) return '';
+  try {
+    return new Intl.DateTimeFormat('zh-CN', { hour:'2-digit', minute:'2-digit', hour12:false }).format(new Date(updatedAt)) + ' 同步';
+  } catch (e) {
+    return '';
+  }
+}
+function normalizeMojiWeather(body, city) {
+  var payload = body && body.data && typeof body.data === 'object' ? body.data : null;
+  var result = payload && payload.result && typeof payload.result === 'object' ? payload.result : null;
+  var current = result && result.condition && typeof result.condition === 'object' ? result.condition : null;
+  var rows = result && Array.isArray(result.forecastDayList) ? result.forecastDayList : [];
+  if (!current) throw new Error('墨迹天气实况数据为空');
+  var todayKey = String(result && result.date && result.date.today || '').trim();
+  var today = rows.find(function(item){
+    return String(item && item.fpredict_date || '').trim() === todayKey;
+  }) || rows.find(function(item){ return item && item.condition; }) || rows[0] || {};
+  var currentTemperature = String(current.ftemp == null ? '' : current.ftemp).replace(/℃/g, '').trim();
+  var feelsLike = String(current.freal_feel == null ? '' : current.freal_feel).replace(/℃/g, '').trim();
+  var low = String(today.ftemp_low == null ? '' : today.ftemp_low).replace(/℃/g, '').trim();
+  var high = String(today.ftemp_high == null ? '' : today.ftemp_high).replace(/℃/g, '').trim();
+  var windDirection = String(current.fwind_dir || today.fwind_dir_day || '').trim();
+  var windLevel = String(current.fwind_level == null ? '' : current.fwind_level).trim();
+  var humidity = String(current.fhumidity == null ? '' : current.fhumidity).replace(/%/g, '').trim();
+  return {
+    city: String(payload.city || city || '').trim(),
+    condition: String(current.fcondition || today.fcondition_day || '').trim(),
+    currentTemperature: currentTemperature ? currentTemperature + '℃' : '',
+    feelsLike: feelsLike ? feelsLike + '℃' : '',
+    todayTemperature: low && high ? low + '～' + high + '℃' : '',
+    wind: [windDirection, windLevel ? windLevel + '级' : ''].filter(Boolean).join(' '),
+    humidity: humidity ? humidity + '%' : '',
+    airQuality: String(result && result.aqi && result.aqi.level || today.aqiDesc || '').trim()
+  };
+}
+function renderHomeWeather() {
+  var icon = document.getElementById('home-weather-icon');
+  var title = document.getElementById('home-weather-now-title');
+  var sub = document.getElementById('home-weather-now-sub');
+  var enable = document.getElementById('home-weather-enable');
+  if (!icon || !title || !sub || !enable) return;
+  if (homeWeatherState.status === 'loading') {
+    icon.textContent = homeWeatherState.data ? weatherIconForCondition(homeWeatherState.data.condition) : '…';
+    title.textContent = homeWeatherState.city || '正在定位城市';
+    sub.textContent = homeWeatherState.city ? '正在同步墨迹天气…' : '首次授权后只保存城市名，不保存坐标';
+    enable.textContent = '同步中';
+    enable.disabled = true;
+    return;
+  }
+  enable.disabled = false;
+  if (homeWeatherState.status === 'ready' && homeWeatherState.data) {
+    var data = homeWeatherState.data;
+    var details = [
+      data.currentTemperature ? ('当前 ' + data.currentTemperature) : '',
+      data.condition,
+      data.feelsLike ? ('体感 ' + data.feelsLike) : '',
+      data.todayTemperature ? ('今日 ' + data.todayTemperature) : data.temperature,
+      data.wind,
+      data.humidity ? ('湿度 ' + data.humidity) : '',
+      data.airQuality ? ('空气 ' + data.airQuality) : '',
+      homeWeatherSyncLabel(homeWeatherState.updatedAt)
+    ].filter(Boolean);
+    icon.textContent = weatherIconForCondition(data.condition);
+    title.textContent = homeWeatherState.city || data.city || '当前城市';
+    sub.textContent = details.join(' · ') + (homeWeatherState.error ? ' · 使用上次数据' : '');
+    enable.textContent = '同步';
+    return;
+  }
+  icon.textContent = homeWeatherState.status === 'error' ? '!' : '◌';
+  title.textContent = homeWeatherState.city || (homeWeatherState.status === 'error' ? '天气暂时不可用' : '授权后显示城市天气');
+  sub.textContent = homeWeatherState.status === 'error' ? (homeWeatherState.error || '请稍后重试') : '首次授权定位后会记住城市，下次自动同步';
+  enable.textContent = homeWeatherState.city ? '重新同步' : '授权定位';
+}
+function fetchMojiWeather(city) {
+  city = String(city || '').trim().slice(0, 80);
+  if (!city) return Promise.reject(new Error('城市名为空'));
+  var cachedData = homeWeatherState.data;
+  var cachedUpdatedAt = homeWeatherState.updatedAt;
+  homeWeatherState = { status:'loading', city:city, data:cachedData, error:'', updatedAt:cachedUpdatedAt };
+  renderHomeWeather();
+  var controller = new AbortController();
+  var timeout = setTimeout(function(){ controller.abort(); }, 10000);
+  var request = window.desktopWindow && typeof window.desktopWindow.fetchMojiWeather === 'function'
+    ? window.desktopWindow.fetchMojiWeather(city).then(function(result){
+        if (!result || !result.ok) throw new Error(String(result && result.error || '墨迹天气请求失败'));
+        return result.body;
+      })
+    : fetch('https://api.xcvts.cn/api/weather/mojicax?city=' + encodeURIComponent(city) + '&n=1&num=20', { signal:controller.signal })
+        .then(function(response){ if (!response.ok) throw new Error('墨迹天气服务返回 ' + response.status); return response.json(); });
+  return request
+    .then(function(body){
+      var data = normalizeMojiWeather(body, city);
+      var updatedAt = Date.now();
+      homeWeatherState = { status:'ready', city:data.city || city, data:data, error:'', updatedAt:updatedAt };
+      saveHomeWeatherCache(homeWeatherState.city, data, updatedAt);
+      renderHomeWeather();
+      return data;
+    })
+    .catch(function(error){
+      var message = error && error.name === 'AbortError' ? '墨迹天气同步超时，请重试' : '墨迹天气暂时无法同步，请重试';
+      homeWeatherState = cachedData
+        ? { status:'ready', city:city, data:cachedData, error:message, updatedAt:cachedUpdatedAt }
+        : { status:'error', city:city, data:null, error:message, updatedAt:0 };
+      renderHomeWeather();
+      throw error;
+    })
+    .finally(function(){ clearTimeout(timeout); });
+}
+function resolveWeatherCity(latitude, longitude) {
+  var controller = new AbortController();
+  var timeout = setTimeout(function(){ controller.abort(); }, 9000);
+  var url = 'https://api.bigdatacloud.net/data/reverse-geocode-client?latitude='
+    + encodeURIComponent(String(latitude)) + '&longitude=' + encodeURIComponent(String(longitude)) + '&localityLanguage=zh';
+  return fetch(url, { signal:controller.signal })
+    .then(function(response){ if (!response.ok) throw new Error('城市定位服务返回 ' + response.status); return response.json(); })
+    .then(function(body){
+      var city = String(body && (body.city || body.principalSubdivision || body.locality) || '').trim();
+      if (!city) throw new Error('没有识别到城市');
+      return city;
+    })
+    .finally(function(){ clearTimeout(timeout); });
+}
+function enableLocalWeather(event) {
+  if (event) { event.preventDefault(); event.stopPropagation(); }
+  if (homeWeatherState.status === 'loading') return;
+  var cached = readHomeWeatherCache();
+  var savedCity = String(homeWeatherState.city || cached && cached.city || '').trim();
+  if (savedCity) {
+    fetchMojiWeather(savedCity).catch(function(){});
+    return;
+  }
+  if (!navigator.geolocation) {
+    homeWeatherState = { status:'error', city:'', data:null, error:'当前系统不支持定位', updatedAt:0 };
+    renderHomeWeather();
+    return;
+  }
+  homeWeatherState = { status:'loading', city:'', data:null, error:'', updatedAt:0 };
+  renderHomeWeather();
+  navigator.geolocation.getCurrentPosition(function(position){
+    var latitude = Math.round(Number(position.coords.latitude) * 100) / 100;
+    var longitude = Math.round(Number(position.coords.longitude) * 100) / 100;
+    resolveWeatherCity(latitude, longitude).then(function(city){
+      saveHomeWeatherCache(city, null, 0);
+      fetchMojiWeather(city).catch(function(){});
+    }, function(error){
+      homeWeatherState = { status:'error', city:'', data:null, error:error && error.name === 'AbortError' ? '城市定位超时，请重试' : '暂时无法识别所在城市，请重试', updatedAt:0 };
+      renderHomeWeather();
+    });
+  }, function(error){
+    var denied = error && error.code === 1;
+    homeWeatherState = { status:'error', city:'', data:null, error:denied ? '未获得定位权限；允许一次后会记住城市' : '暂时无法取得位置，请重试', updatedAt:0 };
+    renderHomeWeather();
+  }, { enableHighAccuracy:false, timeout:9000, maximumAge:30 * 60 * 1000 });
+}
+function initHomeWeather() {
+  var cached = readHomeWeatherCache();
+  if (cached) {
+    homeWeatherState = cached.data
+      ? { status:'ready', city:cached.city, data:cached.data, error:'', updatedAt:cached.updatedAt }
+      : { status:'idle', city:cached.city, data:null, error:'', updatedAt:0 };
+    renderHomeWeather();
+    fetchMojiWeather(cached.city).catch(function(){});
+  } else {
+    renderHomeWeather();
+  }
+  if (homeWeatherRefreshTimer) clearInterval(homeWeatherRefreshTimer);
+  homeWeatherRefreshTimer = setInterval(function(){
+    var latest = readHomeWeatherCache();
+    var city = String(homeWeatherState.city || latest && latest.city || '').trim();
+    if (city && homeWeatherState.status !== 'loading') fetchMojiWeather(city).catch(function(){});
+  }, 30 * 60 * 1000);
+}
+
 function renderHomeMosaic(items) {
   var cells = document.querySelectorAll('#home-mosaic .home-mosaic-cell');
   if (!cells.length) return;
@@ -17948,6 +18292,7 @@ function songDurationLabel(song) {
 function songSourceLabel(song) {
   if (!song) return '未知';
   if (song.type === 'local') return '本地上传';
+  if (song.type === 'kugou') return '酷狗在线';
   return '本地音乐';
 }
 function isLocalPlaceholderArtist(text) {
@@ -18047,6 +18392,9 @@ function songDisplaySubtitleCacheKey(song) {
     (song.localFormat || '') + '|' +
     (song.localFileSize || song.size || 0) + '|' +
     (song.localBitrateKbps || '') + '|' +
+    (song.kugouBitrateKbps || '') + '|' +
+    (song.kugouQualityLabel || '') + '|' +
+    (song.kugouFormat || '') + '|' +
     (song.duration || '') + '|' +
     (song.durationMs || '') + '|' +
     (song.dt || '') + '|' +
@@ -18072,6 +18420,12 @@ function songDisplaySubtitle(song) {
     song._mineradioSubtitleKey = songDisplaySubtitleCacheKey(song);
     song._mineradioSubtitleText = text;
     return text;
+  }
+  if (song.type === 'kugou') {
+    var kugouQuality = '酷狗';
+    if (song.kugouQualityLabel) kugouQuality += ' · ' + song.kugouQualityLabel;
+    if (song.kugouBitrateKbps) kugouQuality += ' · ' + Math.round(song.kugouBitrateKbps) + ' kbps';
+    text = text ? (text + ' · ' + kugouQuality) : kugouQuality;
   }
   text = text || songSourceLabel(song);
   song._mineradioSubtitleKey = beforeKey;
@@ -18579,6 +18933,7 @@ function updateCustomLyricControls() {
 }
 function currentLyricSourceLabel() {
   if (lyricSourceMode === 'custom') return '自定义歌词';
+  if (lyricsTimingSource === 'kugou-lrc') return '酷狗同步歌词';
   return lyricsTimingSource === 'fallback' ? '占位歌词' : '原词';
 }
 function setCustomLyricStatus(text, tone) {
@@ -18836,6 +19191,7 @@ function avatarSrc(url) {
 var searchTimer = null;
 var searchRequestSeq = 0;
 var searchLastResultQuery = '';
+var kugouSearchState = { status: 'idle', count: 0, message: '' };
 var SEARCH_HISTORY_STORE_KEY = 'mineradio-search-history';
 var searchHistoryCache = null;
 var $input = document.getElementById('search-input');
@@ -18860,6 +19216,7 @@ function searchResultKey(q, mode) {
 function clearSearchResults() {
   searchRequestSeq++;
   searchLastResultQuery = '';
+  kugouSearchState = { status: 'idle', count: 0, message: '' };
   searchResultsLastDomSignature = '';
   playlist = [];
   $results.innerHTML = '';
@@ -18961,7 +19318,7 @@ function updateSearchModeTabs() {
     songBtn.setAttribute('aria-selected', searchMode === 'song' ? 'true' : 'false');
   }
   if ($input) {
-    $input.placeholder = '搜索本地歌曲、歌手、文件名...';
+    $input.placeholder = '搜索本地歌曲与酷狗曲库...';
   }
   scheduleGlassDisplacementMapUpdate('searchPill');
 }
@@ -19048,18 +19405,25 @@ document.addEventListener('click', function(e){
 updateSearchModeTabs();
 
 function songProviderKey(song) {
-  return 'local';
+  return song && song.type === 'kugou' ? 'kugou' : 'local';
 }
 function songSourceTagHtml(song) {
-  return '<span class="tag-source local">LOCAL</span>';
+  return songProviderKey(song) === 'kugou'
+    ? '<span class="tag-source kugou">KUGOU</span>'
+    : '<span class="tag-source local">LOCAL</span>';
 }
 function searchResultMetaText(song) {
   var bits = [];
   var artist = songArtistText(song);
   if (artist) bits.push(artist);
   if (song && song.album) bits.push(song.album);
-  var quality = localAudioQualityText(song);
-  if (quality) bits.push(quality);
+  if (song && song.type === 'kugou') {
+    if (song.duration) bits.push(formatProgramTime(song.duration));
+    bits.push('酷狗在线');
+  } else {
+    var quality = localAudioQualityText(song);
+    if (quality) bits.push(quality);
+  }
   return bits.join('  ·  ') || songSourceLabel(song);
 }
 function searchResultMetaHtml(song, index) {
@@ -19067,8 +19431,13 @@ function searchResultMetaHtml(song, index) {
   var artist = songArtistText(song);
   var bits = [];
   if (song.album) bits.push(song.album);
-  var quality = localAudioQualityText(song);
-  if (quality) bits.push(quality);
+  if (song.type === 'kugou') {
+    if (song.duration) bits.push(formatProgramTime(song.duration));
+    bits.push('酷狗在线');
+  } else {
+    var quality = localAudioQualityText(song);
+    if (quality) bits.push(quality);
+  }
   var tail = bits.length ? (' · ' + escHtml(bits.join('  ·  '))) : '';
   if (!artist) return escHtml(searchResultMetaText(song));
   return '<button class="search-artist-link" type="button" onclick="event.stopPropagation();openSearchResultArtist(' + index + ')">' + escHtml(artist) + '</button>' + tail;
@@ -19262,7 +19631,10 @@ function markQueueContentChanged() {
 }
 function searchResultsDomSignature(songs, key) {
   var list = songs || [];
-  var signature = 'search|' + (key || '') + '|' + list.length;
+  var signature = 'search|' + (key || '') + '|' + list.length + '|online:' +
+    String(kugouSearchState && kugouSearchState.status || 'idle') + ':' +
+    String(kugouSearchState && kugouSearchState.count || 0) + ':' +
+    String(kugouSearchState && kugouSearchState.message || '');
   for (var i = 0; i < list.length; i++) {
     var song = list[i] || {};
     signature += '|' +
@@ -19341,8 +19713,71 @@ function renderLocalLibraryResults(q, opts) {
   renderSongSearchResults(songs);
   if (opts.autoPlayFirst) playSearchResult(0);
 }
+function normalizeKugouSearchSong(track, index) {
+  track = track || {};
+  var hash = String(track.hash || '').trim();
+  var name = String(track.name || '').trim();
+  if (!/^[a-f0-9]{32}$/i.test(hash) || !name) return null;
+  return {
+    type: 'kugou',
+    provider: 'kugou',
+    source: 'kugou',
+    id: 'kugou-search:' + String(track.id || hash || index),
+    hash: hash,
+    albumId: String(track.albumId || '0'),
+    albumAudioId: String(track.albumAudioId || '0'),
+    name: name,
+    artist: String(track.artist || '未知歌手').trim(),
+    album: String(track.album || '').trim(),
+    duration: Math.max(0, Number(track.duration) || 0),
+    cover: String(track.cover || '').trim(),
+    onlineSearchResult: true
+  };
+}
 async function fetchMusicSearchResults(q, mode) {
-  return searchLocalSongs(q);
+  var localSongs = searchLocalSongs(q);
+  var api = getDesktopWindowApi();
+  if (!api || typeof api.searchKugouTracks !== 'function') {
+    kugouSearchState = { status: 'unsupported', count: 0, message: '当前版本暂不支持酷狗在线搜索' };
+    return localSongs;
+  }
+  try {
+    var result = await api.searchKugouTracks(q, { page: 1, pageSize: 20 });
+    if (!result || result.ok !== true) {
+      var code = String(result && result.error || 'KUGOU_SEARCH_FAILED');
+      if (code === 'KUGOU_NOT_LOGGED_IN' || result && result.loggedIn === false) {
+        kugouSearchState = { status: 'login', count: 0, message: '登录酷狗后即可搜索完整曲库' };
+      } else {
+        kugouSearchState = { status: 'error', count: 0, message: '酷狗在线搜索暂时不可用，请稍后重试' };
+      }
+      return localSongs;
+    }
+    var remoteRows = Array.isArray(result.tracks) ? result.tracks : [];
+    var remoteSongs = [];
+    for (var i = 0; i < remoteRows.length; i++) {
+      var remoteSong = normalizeKugouSearchSong(remoteRows[i], i);
+      if (remoteSong) remoteSongs.push(remoteSong);
+    }
+    kugouSearchState = {
+      status: remoteSongs.length ? 'ready' : 'empty',
+      count: remoteSongs.length,
+      message: remoteSongs.length ? ('找到 ' + remoteSongs.length + ' 首酷狗歌曲') : '酷狗曲库没有找到相关歌曲'
+    };
+    return localSongs.concat(remoteSongs);
+  } catch (error) {
+    console.warn('[KugouSearch]', error);
+    kugouSearchState = { status: 'error', count: 0, message: '酷狗在线搜索连接失败，本地结果仍可使用' };
+    return localSongs;
+  }
+}
+function searchOnlineNoteHtml() {
+  var state = kugouSearchState || { status: 'idle', count: 0, message: '' };
+  if (state.status === 'idle') return '';
+  var action = state.status === 'login'
+    ? '<button type="button" onclick="event.stopPropagation();showLoginModal({source:\'search\'})">登录酷狗</button>'
+    : '';
+  var label = state.status === 'ready' ? ('KUGOU ONLINE · ' + state.count) : 'KUGOU ONLINE';
+  return '<div class="search-online-note"><div><b>' + escHtml(label) + '</b><div>' + escHtml(state.message || '') + '</div></div>' + action + '</div>';
 }
 function renderSongSearchResults(songs) {
   playlist = songs || [];
@@ -19366,7 +19801,8 @@ function renderSongSearchResults(songs) {
     var imgTag = thumb
       ? '<img src="' + thumb + '" alt="" loading="lazy" onerror="this.style.opacity=0.2">'
       : '<div style="width:40px;height:40px;border-radius:6px;background:rgba(255,255,255,0.06);flex-shrink:0"></div>';
-    resultHtml += '<div class="search-result local-source">' +
+    var providerKey = songProviderKey(s);
+    resultHtml += '<div class="search-result ' + providerKey + '-source">' +
       '<div style="display:flex;align-items:center;gap:12px;flex:1;min-width:0" onclick="playSearchResult(' + i + ')">' +
         imgTag +
         '<div class="search-result-info">' +
@@ -19377,6 +19813,7 @@ function renderSongSearchResults(songs) {
       '<button class="add-btn" title="下一首播放" onclick="event.stopPropagation();queueSearchResult(' + i + ')">+</button>' +
     '</div>';
   }
+  resultHtml += searchOnlineNoteHtml();
   $results.innerHTML = resultHtml;
   $results.classList.add('show');
   if (shouldAnimate) {
@@ -19400,11 +19837,11 @@ async function doSearch(q, opts) {
       playlist = [];
       searchLastResultQuery = '';
       searchResultsLastDomSignature = '';
-      $results.innerHTML = '<div class="search-empty">本地库里没有找到相关歌曲</div>';
+      $results.innerHTML = '<div class="search-empty">本地音乐和酷狗曲库里都没有找到相关歌曲</div>' + searchOnlineNoteHtml();
       $results.classList.add('show');
       return;
     }
-    searchLastResultQuery = searchResultKey(q, 'local');
+    searchLastResultQuery = searchResultKey(q);
     rememberSearchQuery(q);
     renderSongSearchResults(songs);
     if (opts.autoPlayFirst) playSearchResult(0);
@@ -19986,8 +20423,12 @@ function playSearchResult(i) {
     if (matchIdx >= 0) currentIdx = moveQueueIndexToTop(matchIdx);
     else { playQueue.unshift(cloneSong(song)); markQueueContentChanged(); currentIdx = 0; }
   }
-  $results.classList.remove('show');
-  $input.value = ''; $input.blur();
+  clearTimeout(searchTimer);
+  $input.value = '';
+  $input.blur();
+  clearSearchResults();
+  syncSearchAreaResultState();
+  if (!emptyHomeActive) setPeek(document.getElementById('search-area'), false, 'search');
   playQueueAt(currentIdx);
 }
 var firstPlayDone = false;
@@ -20146,6 +20587,71 @@ function applyLocalOriginalLyricsState(song) {
   setOriginalLyricsState(withLyricFallback(lines), false, timingSource);
   applyPreferredLyricsForCurrent(true);
 }
+function isCurrentKugouQueueSong(song) {
+  return !!(song && currentIdx >= 0 && playQueue[currentIdx] === song && song.type === 'kugou');
+}
+function applyKugouOriginalLyricsState(song) {
+  var text = song && String(song.kugouLyricText || '').trim();
+  var lines = text ? parseLyricText(text) : [];
+  for (var i = 0; i < lines.length; i++) lines[i].source = 'kugou-lrc';
+  setOriginalLyricsState(withLyricFallback(lines), false, lines.length ? 'kugou-lrc' : 'fallback');
+  applyPreferredLyricsForCurrent(true);
+  if (fx && fx.particleLyrics) createLyricsParticles();
+  pushDesktopLyricsState(true);
+}
+function maybeApplyKugouLyricsForSong(song, token) {
+  if (token !== trackSwitchToken || !isCurrentKugouQueueSong(song)) return;
+  applyKugouOriginalLyricsState(song);
+  updateCustomLyricControls();
+}
+function loadKugouLyricsForSong(song, token) {
+  if (!song || song.type !== 'kugou') return Promise.resolve(false);
+  var currentHash = String(song.hash || '').trim().toLowerCase();
+  if (song.kugouLyricLoaded && song.kugouLyricHash === currentHash) {
+    maybeApplyKugouLyricsForSong(song, token);
+    return Promise.resolve(!!String(song.kugouLyricText || '').trim());
+  }
+  if (song.kugouLyricPromise && song.kugouLyricHash === currentHash) {
+    return song.kugouLyricPromise.then(function(ok){
+      maybeApplyKugouLyricsForSong(song, token);
+      return ok;
+    });
+  }
+  var api = getDesktopWindowApi();
+  if (!api || typeof api.getKugouLyrics !== 'function') return Promise.resolve(false);
+  song.kugouLyricHash = currentHash;
+  song.kugouLyricLoading = true;
+  song.kugouLyricPromise = api.getKugouLyrics({
+    hash: song.hash,
+    albumAudioId: song.albumAudioId,
+    duration: song.duration,
+    name: song.name,
+    artist: song.artist
+  }).then(function(result){
+    if (song.kugouLyricHash !== currentHash) return false;
+    song.kugouLyricText = result && result.ok === true ? String(result.lyric || '').trim() : '';
+    song.kugouLyricLoaded = true;
+    maybeApplyKugouLyricsForSong(song, token);
+    if (song.kugouLyricText && isCurrentKugouQueueSong(song) && fx && !fx.particleLyrics) {
+      showToast('酷狗歌词已同步，点击“词”即可显示');
+    }
+    return !!song.kugouLyricText;
+  }).catch(function(error){
+    console.warn('[KugouLyrics]', song && song.name, error);
+    if (song.kugouLyricHash === currentHash) {
+      song.kugouLyricText = '';
+      song.kugouLyricLoaded = true;
+      maybeApplyKugouLyricsForSong(song, token);
+    }
+    return false;
+  }).finally(function(){
+    if (song.kugouLyricHash === currentHash) {
+      song.kugouLyricLoading = false;
+      song.kugouLyricPromise = null;
+    }
+  });
+  return song.kugouLyricPromise;
+}
 function canReadEmbeddedFlacLyrics(song) {
   return !!(song && song.localFile && /\.flac$/i.test(song.localFile.name || song.localPath || song.localFilePathAbsolute || ''));
 }
@@ -20300,6 +20806,126 @@ async function playLocalQueueItem(song, idx, opts, token, firstVisualPlay, bmKey
   safePlaybackStep('shelf-preview-suppress-end', suppressShelfPreviewForPlaybackSwitch);
 }
 
+async function playKugouQueueItem(song, idx, opts, token, firstVisualPlay, bmKey, markPlayPhase) {
+  markPlayPhase('kugou-stream-url');
+  var api = getDesktopWindowApi();
+  if (!api || typeof api.getKugouStreamUrl !== 'function') throw new Error('当前版本不支持酷狗在线播放');
+  var result = await api.getKugouStreamUrl({
+    hash: song.hash,
+    albumId: song.albumId,
+    albumAudioId: song.albumAudioId,
+    name: song.name,
+    artist: song.artist,
+    quality: opts.qualityOverride || playbackQuality
+  });
+  if (token !== trackSwitchToken || playQueue[idx] !== song) return;
+  if (!result || result.ok !== true || !result.url) {
+    var errorCode = String(result && result.error || 'KUGOU_STREAM_URL_EMPTY');
+    if (errorCode === 'KUGOU_SESSION_EXPIRED' || errorCode === 'KUGOU_NOT_LOGGED_IN') throw new Error('酷狗登录已过期，请重新登录');
+    if (errorCode === 'KUGOU_STREAM_IDENTITY_MISMATCH') {
+      var actualFileName = String(result && result.actualFileName || '').trim();
+      var identityError = new Error(actualFileName
+        ? ('酷狗实际返回「' + actualFileName + '」，与歌单不一致，已停止播放')
+        : '酷狗返回了不同版本，已停止播放，避免播错歌');
+      identityError.preventAutoSkip = true;
+      throw identityError;
+    }
+    if (errorCode === 'KUGOU_STREAM_URL_EMPTY') throw new Error('酷狗暂未返回这首歌的播放地址');
+    throw new Error('酷狗播放地址获取失败（' + errorCode + '）');
+  }
+  if (result.matchedTrack && typeof result.matchedTrack === 'object') {
+    var matchedHash = String(result.matchedTrack.hash || '').trim();
+    if (/^[a-f0-9]{32}$/i.test(matchedHash)) {
+      if (String(song.hash || '').toLowerCase() !== matchedHash.toLowerCase()) {
+        song.kugouLyricLoaded = false;
+        song.kugouLyricText = '';
+        song.kugouLyricHash = '';
+      }
+      song.hash = matchedHash;
+    }
+    song.albumId = String(result.matchedTrack.albumId || song.albumId || '0');
+    song.albumAudioId = String(result.matchedTrack.albumAudioId || song.albumAudioId || '0');
+  }
+  song.kugouMatchedBySearch = result.matchedBySearch === true;
+  song.kugouBitrateKbps = Math.max(0, Math.round((Number(result.bitRate) || 0) / 1000));
+  song.kugouQualityLevel = String(result.resolvedLevel || '');
+  song.kugouQualityLabel = String(result.qualityLabel || playbackQualityLabel(result.resolvedLevel || playbackQuality));
+  song.kugouFormat = String(result.format || '').toUpperCase();
+  song.kugouIdentityVerified = result.identityVerified === true;
+  if (Number(result.duration) > 0) song.duration = Number(result.duration);
+  currentLocalSong = null;
+  document.getElementById('trial-banner').classList.remove('show');
+  loadCoverFromUrl(songCoverSrc(song, 640), { trackToken: token });
+  loadKugouLyricsForSong(song, token);
+
+  markPlayPhase('audio-element');
+  if (!audio) { audio = new Audio(); audio.crossOrigin = 'anonymous'; }
+  else {
+    audioFadeSerial++;
+    clearAudioFadeTimers();
+    audio.pause();
+  }
+  bindPlaybackProgressEvents(audio);
+  applyVolumeToAudio();
+  audio.src = result.url;
+  schedulePlaybackProgressUi('audio-source', true);
+  audio.onended = function(){
+    if (token !== trackSwitchToken) return;
+    finalizeListenSession(true);
+    if (playMode === 'single') setTimeout(function(){ playQueueAt(currentIdx, { autoRepeat: true }); }, 0);
+    else setTimeout(nextTrack, 0);
+  };
+  audio.onloadedmetadata = function(){
+    if (token !== trackSwitchToken || playQueue[idx] !== song) return;
+    if (audio && isFinite(audio.duration) && audio.duration > 0) song.duration = audio.duration;
+    updateControlTrackInfo(song);
+    var thumbArtist = document.getElementById('thumb-artist');
+    if (thumbArtist) thumbArtist.textContent = songDisplaySubtitle(song);
+    safeRenderQueuePanel('kugou-metadata', { scrollCurrent: miniQueueOpen });
+  };
+  scheduleAudioResumePosition(audio, opts.resumeAt, token);
+  audio.load();
+
+  markPlayPhase('visual-prep');
+  try {
+    currentBeatMap = null;
+    beatMapNextIdx = 0;
+    resetAudioVisualState();
+    resetBeatCameraSync(0);
+    cancelBeatAnalysisTimer();
+    cancelDjBeatAnalysisTimer();
+    beatMapToken++;
+    djBeatMapToken++;
+    resetDjBeatMapState();
+    setDjModeActive(false);
+    hideBeatChip();
+    notifyDesktopLyricsBeatMapReady();
+  } catch (visualErr) {
+    console.warn('[KugouPlaybackVisualPrep]', song && song.name, visualErr);
+  }
+
+  markPlayPhase('audio-start');
+  var playbackStarted = await playAudio({ manual: !!opts.manual, silent: false });
+  if (!playbackStarted) {
+    forcePlaybackControlsInteractive();
+    showToast(opts.manual ? '酷狗音乐启动失败，请再试一次' : '歌曲已载入，点击播放按钮继续播放');
+    return;
+  }
+  if (result.matchedBySearch) {
+    showToast('原歌单链接不可用，已按歌名和歌手重新匹配播放');
+  } else if (result.downgraded) {
+    showToast(playbackQualityLabel(result.requestedLevel) + '暂不可用，已使用' + song.kugouQualityLabel);
+  } else if (opts.qualitySwitch) {
+    showToast('已切换到' + song.kugouQualityLabel);
+  }
+  forcePlaybackControlsInteractive();
+  markPlayPhase('session-begin');
+  safePlaybackStep('listen-session-begin', function(){ beginListenSession(song, opts.context || null); });
+  safeRenderQueuePanel('play-kugou-queue-item');
+  scheduleShelfRebuild('play-kugou-queue-item', true);
+  safePlaybackStep('shelf-preview-suppress-end', suppressShelfPreviewForPlaybackSwitch);
+}
+
 async function playQueueAt(idx, opts) {
   opts = opts || {};
   if (idx < 0 || idx >= playQueue.length) return;
@@ -20327,14 +20953,16 @@ async function playQueueAt(idx, opts) {
     var song = safePlaybackStep('hydrate-song', function(){ return hydrateCustomCover(playQueue[idx]); }) || playQueue[idx];
     playQueue[idx] = song;
     markQueueContentChanged();
-    if (!song || song.type !== 'local') {
+    if (!song || (song.type !== 'local' && song.type !== 'kugou')) {
       hideLoading();
       forcePlaybackControlsInteractive();
-      showToast('纯本地播放器只播放本地音乐文件');
+      showToast('当前歌曲来源暂不支持播放');
       return;
     }
-    markPlayPhase('local-metadata');
-    updateLocalAudioQualityInfo(song);
+    document.body.classList.toggle('kugou-online-playing', song.type === 'kugou');
+    safePlaybackStep('quality-ui', updatePlaybackQualityUi);
+    markPlayPhase(song.type === 'local' ? 'local-metadata' : 'kugou-metadata');
+    if (song.type === 'local') updateLocalAudioQualityInfo(song);
     activePlaybackContext = null;
     safeRenderQueuePanel('play-local-queue-at-switch', { scrollCurrent: miniQueueOpen });
     safePlaybackStep('shelf-preview-suppress', suppressShelfPreviewForPlaybackSwitch);
@@ -20369,12 +20997,14 @@ async function playQueueAt(idx, opts) {
         tweenParticleAlpha(uniforms.uAlpha.value || 0, 1.0, 220);
       });
     }
-    await playLocalQueueItem(song, idx, opts, token, firstVisualPlay, bmKey, markPlayPhase);
+    if (song.type === 'local') await playLocalQueueItem(song, idx, opts, token, firstVisualPlay, bmKey, markPlayPhase);
+    else await playKugouQueueItem(song, idx, opts, token, firstVisualPlay, bmKey, markPlayPhase);
   } catch (setupErr) {
     console.error('Play setup failed:', { phase: playPhase, error: setupErr }, setupErr);
     hideLoading();
     forcePlaybackControlsInteractive();
-    if (!isPlaybackRecursionError(setupErr) && token === trackSwitchToken && !opts.manual && playQueue.length > 1) {
+    if (opts.propagateError) throw setupErr;
+    if (!isPlaybackRecursionError(setupErr) && !setupErr.preventAutoSkip && token === trackSwitchToken && !opts.manual && playQueue.length > 1) {
       skipFailedQueueItem(idx, token, '当前歌曲切换失败，正在尝试队列里的下一首。');
       return;
     }
@@ -21565,7 +22195,7 @@ function schedulePlaylistPanelLazyCheck() {
     if (!panel) return;
     maybeGrowQueuePanelRenderLimit();
     maybeGrowPlaylistPanelDetailRenderLimit();
-    var total = LOCAL_ONLY_MODE ? (localLibrarySongs || []).length : userPlaylists.length;
+    var total = (localLibrarySongs || []).length + (hasPlatformLogin('kugou') ? userPlaylists.length : 0);
     if (queueViewTab !== 'playlists' || playlistPanelRenderLimit >= total) return;
     if (panel.scrollTop + panel.clientHeight >= panel.scrollHeight - 180) growPlaylistPanelRenderLimit();
   });
@@ -21638,14 +22268,48 @@ function renderQueuePanel(opts) {
 }
 async function refreshUserPlaylists(force) {
   if (force) resetPlaylistPanelRenderLimit();
-  renderLocalLibraryPlaylistPanel({ animate: isPlaylistPanelVisibleForRender() });
+  if (!hasPlatformLogin('kugou')) {
+    renderLocalLibraryPlaylistPanel({ animate: isPlaylistPanelVisibleForRender() });
+    return [];
+  }
+  if (!force && (kugouPlaylistsLoading || userPlaylists.length)) {
+    renderUserPlaylistsList({ animate: isPlaylistPanelVisibleForRender() });
+    return userPlaylists;
+  }
+  var api = getDesktopWindowApi();
+  if (!api || typeof api.getKugouPlaylists !== 'function') {
+    renderUserPlaylistsList({ animate: isPlaylistPanelVisibleForRender() });
+    return userPlaylists;
+  }
+  kugouPlaylistsLoading = true;
+  updateUserModalUi();
+  playlistPanelLastDomSignature = '';
+  renderUserPlaylistsList({ animate: false });
+  try {
+    var result = await api.getKugouPlaylists();
+    if (!result || result.ok !== true) {
+      if (result && result.loggedIn === false) await refreshLoginStatus(true);
+      throw new Error(result && result.error || 'KUGOU_PLAYLISTS_FAILED');
+    }
+    userPlaylists = Array.isArray(result.playlists) ? result.playlists : [];
+    kugouPlaylistsSyncedAt = Number(result.syncedAt) || Date.now();
+  } catch (e) {
+    console.warn('[KugouPlaylists]', e);
+    if (force) showToast('酷狗歌单同步失败，请稍后再试');
+  } finally {
+    kugouPlaylistsLoading = false;
+    playlistPanelLastDomSignature = '';
+    renderUserPlaylistsList({ animate: isPlaylistPanelVisibleForRender() });
+    updateUserModalUi();
+  }
+  return userPlaylists;
 }
-var playlistPanelDetailState = { key: '', loading: false, playlist: null, tracks: [], token: 0, renderLimit: playlistDetailInitialRenderLimit() };
+var playlistPanelDetailState = { key: '', loading: false, playlist: null, tracks: [], remoteTotal: 0, matchedCount: 0, token: 0, renderLimit: playlistDetailInitialRenderLimit() };
 function playlistPanelKey(provider, id) {
-  return 'local:' + String(id || '');
+  return String(provider || 'local') + ':' + String(id || '');
 }
 function playlistPanelProviderId(provider, id) {
-  return 'local:' + String(id || '');
+  return playlistPanelKey(provider, id);
 }
 function playlistPanelDetailHtml(pl, provider) {
   var key = playlistPanelKey(provider, pl && pl.id);
@@ -21672,7 +22336,7 @@ function playlistPanelDetailHtml(pl, provider) {
       '</div>';
     }
   }
-  if (!loading && !rows) rows = '<div style="text-align:center;padding:14px 0;color:rgba(255,255,255,.30);font-size:11.5px">歌单暂无可播放歌曲</div>';
+  if (!loading && !rows) rows = '<div style="text-align:center;padding:14px 0;color:rgba(255,255,255,.30);font-size:11.5px">酷狗歌单暂时没有可播放歌曲</div>';
   if (!loading && tracks.length > renderLimit) {
     rows += '<button type="button" class="fx-mini-btn ghost pl-detail-load-more" data-pl-detail-load-more="1">加载更多 ' + renderLimit + '/' + tracks.length + '</button>';
   } else if (!loading && tracks.length > detailInitialLimit) {
@@ -21680,7 +22344,7 @@ function playlistPanelDetailHtml(pl, provider) {
   }
   return '<div class="pl-inline-detail" data-pl-detail="' + escHtml(key) + '">' +
     '<div class="pl-detail-sticky">' +
-      '<div class="pl-detail-head">' + img + '<div style="flex:1;min-width:0"><div class="pl-detail-title">' + escHtml(pl.name || '歌单详情') + '</div><div class="pl-detail-sub">' + escHtml((pl.trackCount || tracks.length || 0) + ' 首 · ' + (pl.creator || '本地音乐库')) + '</div></div><div class="pl-detail-count">' + (loading ? '载入中' : (renderLimit + '/' + tracks.length)) + '</div></div>' +
+      '<div class="pl-detail-head">' + img + '<div style="flex:1;min-width:0"><div class="pl-detail-title">' + escHtml(pl.name || '歌单详情') + '</div><div class="pl-detail-sub">' + escHtml(loading ? '正在读取酷狗歌单' : (tracks.length + '/' + (playlistPanelDetailState.remoteTotal || pl.trackCount || tracks.length) + ' 首可播放 · ' + (playlistPanelDetailState.matchedCount || 0) + ' 首优先使用本地文件')) + '</div></div><div class="pl-detail-count">' + (loading ? '载入中' : (renderLimit + '/' + tracks.length)) + '</div></div>' +
       '<div class="pl-detail-actions"><button class="pl-detail-play" type="button" data-pl-detail-play="' + escHtml(key) + '"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>播放歌单</button><button class="fx-mini-btn ghost pl-detail-top-btn" type="button" data-pl-detail-top="1">回到顶部</button></div>' +
     '</div>' +
     '<div class="pl-detail-list">' + rows + '</div>' +
@@ -21714,11 +22378,127 @@ function scrollPlaylistPanelDetailIntoView(key) {
     catch (e) { panel.scrollTop = top; }
   });
 }
+function kugouMatchText(value) {
+  var text = String(value || '').toLowerCase();
+  try { text = text.normalize('NFKC'); } catch (e) {}
+  return text.replace(/[\s\-_.·•'’"“”《》【】()\[\]{}:：,，!！?？/\\]+/g, '');
+}
+function matchKugouTracksToLocalLibrary(remoteTracks) {
+  var locals = localLibraryPlaybackSongs();
+  var exact = Object.create(null);
+  var byTitle = Object.create(null);
+  locals.forEach(function(song){
+    var titleKey = kugouMatchText(song.name || song.title || '');
+    var artistKey = kugouMatchText(songArtistText(song) || song.artist || '');
+    if (!titleKey) return;
+    exact[titleKey + '|' + artistKey] = exact[titleKey + '|' + artistKey] || song;
+    (byTitle[titleKey] || (byTitle[titleKey] = [])).push(song);
+  });
+  var localMatchedCount = 0;
+  var tracks = (remoteTracks || []).map(function(remote){
+    var titleKey = kugouMatchText(remote.name || '');
+    var artistKey = kugouMatchText(remote.artist || '');
+    var local = exact[titleKey + '|' + artistKey] || null;
+    if (!local && byTitle[titleKey] && byTitle[titleKey].length === 1) local = byTitle[titleKey][0];
+    if (!local && byTitle[titleKey] && artistKey) {
+      local = byTitle[titleKey].find(function(candidate){
+        var candidateArtist = kugouMatchText(songArtistText(candidate) || candidate.artist || '');
+        return candidateArtist && (candidateArtist.indexOf(artistKey) >= 0 || artistKey.indexOf(candidateArtist) >= 0);
+      }) || null;
+    }
+    if (local) {
+      localMatchedCount++;
+      return Object.assign({}, local, {
+        kugouTrackId: remote.id || '',
+        kugouHash: remote.hash || '',
+        kugouAlbumId: remote.albumId || '0',
+        kugouAlbumAudioId: remote.albumAudioId || '0',
+        kugouPlaylistMatch: true
+      });
+    }
+    return {
+      type: 'kugou',
+      provider: 'kugou',
+      source: 'kugou',
+      id: 'kugou:' + String(remote.id || remote.hash || (titleKey + ':' + artistKey)),
+      hash: String(remote.hash || ''),
+      albumId: String(remote.albumId || '0'),
+      albumAudioId: String(remote.albumAudioId || remote.id || '0'),
+      name: String(remote.name || '未知歌曲'),
+      artist: String(remote.artist || '未知歌手'),
+      album: String(remote.album || ''),
+      duration: Number(remote.duration) || 0,
+      cover: String(remote.cover || '')
+    };
+  }).filter(function(song){ return song && (song.type === 'local' || (song.hash && song.name)); });
+  return { tracks: tracks, localMatchedCount: localMatchedCount };
+}
 async function openPlaylistPanelDetail(provider, pid, title) {
-  openHomeLibrary();
+  provider = provider || 'kugou';
+  var playlist = userPlaylists.find(function(item){
+    return String(item.id || '') === String(pid || '') || String(item.globalId || '') === String(pid || '');
+  });
+  if (!playlist || provider !== 'kugou') return;
+  var key = playlistPanelKey(provider, playlist.id);
+  if (playlistPanelDetailState.key === key && !playlistPanelDetailState.loading) {
+    playlistPanelDetailState.key = '';
+    renderPlaylistPanelDetailState();
+    return;
+  }
+  var token = (playlistPanelDetailState.token || 0) + 1;
+  playlistPanelDetailState = {
+    key: key,
+    loading: true,
+    playlist: playlist,
+    tracks: [],
+    remoteTotal: Number(playlist.trackCount) || 0,
+    matchedCount: 0,
+    token: token,
+    renderLimit: playlistDetailInitialRenderLimit()
+  };
+  renderPlaylistPanelDetailState();
+  scrollPlaylistPanelDetailIntoView(key);
+  var api = getDesktopWindowApi();
+  if (!api || typeof api.getKugouPlaylistTracks !== 'function') return;
+  try {
+    var result = await api.getKugouPlaylistTracks({ id: playlist.id, globalId: playlist.globalId, listId: playlist.listId });
+    if (playlistPanelDetailState.token !== token) return;
+    if (!result || result.ok !== true) throw new Error(result && result.error || 'KUGOU_PLAYLIST_TRACKS_FAILED');
+    var remoteTracks = Array.isArray(result.tracks) ? result.tracks : [];
+    var resolved = matchKugouTracksToLocalLibrary(remoteTracks);
+    playlist.trackCount = Number(result.total) || remoteTracks.length || playlist.trackCount || 0;
+    playlistPanelDetailState.loading = false;
+    playlistPanelDetailState.tracks = resolved.tracks;
+    playlistPanelDetailState.remoteTotal = Number(result.total) || remoteTracks.length;
+    playlistPanelDetailState.matchedCount = resolved.localMatchedCount;
+    playlistPanelDetailState.renderLimit = playlistDetailInitialRenderLimit();
+    playlistPanelLastDomSignature = '';
+    renderPlaylistPanelDetailState();
+    scrollPlaylistPanelDetailIntoView(key);
+  } catch (e) {
+    if (playlistPanelDetailState.token !== token) return;
+    console.warn('[KugouPlaylistTracks]', e);
+    playlistPanelDetailState.loading = false;
+    playlistPanelDetailState.tracks = [];
+    playlistPanelLastDomSignature = '';
+    renderPlaylistPanelDetailState();
+    showToast('酷狗歌单曲目读取失败');
+  }
 }
 function playPlaylistPanelDetail() {
-  playLocalLibrarySong(0);
+  var tracks = playlistPanelDetailState.tracks || [];
+  if (!tracks.length) {
+    showToast('这个歌单暂时没有可播放歌曲');
+    return;
+  }
+  playQueue = cloneSongList(tracks);
+  markQueueContentChanged();
+  currentIdx = 0;
+  safeRenderQueuePanel('kugou-playlist-detail');
+  safeSwitchPlaylistTab('queue', 'kugou-playlist-detail');
+  safeShelfRebuild('kugou-playlist-detail', true);
+  forcePlaybackControlsInteractive();
+  playQueueAt(0).catch(function(e){ console.warn('[KugouPlaylistPlay]', e); });
 }
 function playPlaylistPanelDetailTrack(index) {
   var tracks = playlistPanelDetailState.tracks || [];
@@ -21779,14 +22559,14 @@ function localLibraryPlaylistDomSignature(songs, renderLimit) {
   return signature;
 }
 function growPlaylistPanelRenderLimit() {
-  var total = LOCAL_ONLY_MODE ? (localLibrarySongs || []).length : userPlaylists.length;
+  var total = localLibraryPlaybackSongs().length;
   if (!total) return;
   var batch = playlistPanelBatchSize();
   var next = Math.min(total, (playlistPanelRenderLimit || batch) + batch);
   if (next <= playlistPanelRenderLimit) return;
   playlistPanelRenderLimit = next;
-  if (LOCAL_ONLY_MODE) renderLocalLibraryPlaylistPanel({ animate: true });
-  else renderUserPlaylistsList({ animate: true });
+  if (hasPlatformLogin('kugou')) renderUserPlaylistsList({ animate: true });
+  else renderLocalLibraryPlaylistPanel({ animate: true });
 }
 function bindPlaylistPanelLazyRender() {
   var panel = document.getElementById('playlist-panel');
@@ -21829,7 +22609,50 @@ function renderLocalLibraryPlaylistPanel(opts) {
   if (opts.animate && seq === playlistRenderSeq) animateVisiblePanelList($pl, '.pl-card', document.getElementById('playlist-panel'));
 }
 function renderUserPlaylistsList(opts) {
-  renderLocalLibraryPlaylistPanel(opts || {});
+  opts = opts || {};
+  var $pl = document.getElementById('pl-list');
+  if (!$pl) return;
+  var songs = localLibraryPlaybackSongs();
+  var seq = ++playlistRenderSeq;
+  var panelBatch = playlistPanelBatchSize();
+  playlistPanelRenderLimit = Math.max(panelBatch, Math.min(songs.length || panelBatch, playlistPanelRenderLimit || panelBatch));
+  var visibleLength = Math.min(songs.length, playlistPanelRenderLimit);
+  var signature = 'kugou|' + (kugouPlaylistsLoading ? 'loading' : 'ready') + '|' + userPlaylists.length + '|' + visibleLength + '|' + playlistPanelDetailState.key + '|' + (playlistPanelDetailState.loading ? 'loading' : playlistPanelDetailState.matchedCount);
+  userPlaylists.forEach(function(pl){ signature += '|' + pl.id + '~' + pl.name + '~' + pl.trackCount; });
+  for (var si = 0; si < visibleLength; si++) signature += '|' + queueItemKey(songs[si]);
+  if (signature === playlistPanelLastDomSignature) return;
+  playlistPanelLastDomSignature = signature;
+  var html = '<div class="pl-section-label">酷狗歌单 · ' + userPlaylists.length + ' 个 <span class="pl-kugou-badge">SYNC</span></div>';
+  if (kugouPlaylistsLoading) {
+    html += '<div style="text-align:center;padding:18px 0;color:rgba(255,255,255,.38);font-size:11.5px">正在同步酷狗歌单…</div>';
+  } else if (!userPlaylists.length) {
+    html += '<div style="text-align:center;padding:18px 0;color:rgba(255,255,255,.32);font-size:11.5px">当前账号没有可同步的歌单</div>';
+  } else {
+    userPlaylists.forEach(function(pl){
+      var thumb = pl.cover || '';
+      var imgTag = thumb ? '<img src="' + escHtml(thumb) + '" alt="" loading="lazy" decoding="async" onerror="this.style.opacity=0.2">' : '<div style="width:44px;height:44px;border-radius:8px;background:rgba(0,245,212,.06);flex-shrink:0"></div>';
+      var key = playlistPanelKey('kugou', pl.id);
+      var expanded = playlistPanelDetailState.key === key;
+      html += '<div class="pl-card kugou-card' + (expanded ? ' expanded' : '') + '" data-playlist-provider="kugou" data-playlist-id="' + escHtml(pl.id) + '" data-playlist-title="' + escHtml(pl.name) + '">' +
+        imgTag + '<div style="flex:1;min-width:0"><div class="pl-name">' + escHtml(pl.name) + '</div><div class="pl-sub">' + escHtml((pl.trackCount || 0) + ' 首 · ' + (pl.subscribed ? '收藏歌单' : '我的歌单')) + '</div></div>' +
+      '</div>';
+      if (expanded) html += playlistPanelDetailHtml(pl, 'kugou');
+    });
+  }
+  html += '<div class="pl-section-label" style="margin-top:14px">本地音乐库 · ' + songs.length + ' 首</div>';
+  if (!songs.length) {
+    html += '<div style="text-align:center;padding:18px 0;color:rgba(255,255,255,.32);font-size:11.5px">酷狗歌单无需本地文件即可播放<br>导入后会优先使用本地歌曲<br><button class="fx-mini-btn ghost" type="button" onclick="openLocalFolderImport()" style="margin-top:10px">导入文件夹</button></div>';
+  } else {
+    for (var i = 0; i < visibleLength; i++) {
+      var song = songs[i] || {};
+      var cover = songCoverSrc(song, 88);
+      var localImg = cover ? '<img src="' + escHtml(cover) + '" alt="" loading="lazy" decoding="async" onerror="this.style.opacity=0.2">' : '<div style="width:44px;height:44px;border-radius:8px;background:rgba(255,255,255,.06);flex-shrink:0"></div>';
+      html += '<div class="pl-card" data-local-library-index="' + i + '">' + localImg + '<div style="flex:1;min-width:0"><div class="pl-name">' + escHtml(song.name || '本地音乐') + '</div><div class="pl-sub">' + escHtml(songDisplaySubtitle(song) || '本地文件') + '</div></div></div>';
+    }
+    if (songs.length > visibleLength) html += '<button type="button" class="fx-mini-btn ghost pl-load-more" data-pl-load-more="1">加载更多 ' + visibleLength + '/' + songs.length + '</button>';
+  }
+  $pl.innerHTML = html;
+  if (opts.animate && seq === playlistRenderSeq) animateVisiblePanelList($pl, '.pl-card', document.getElementById('playlist-panel'));
 }
 function renderMyPodcastCollections(opts) {
   renderLocalLibraryPlaylistPanel(opts || {});
@@ -21886,7 +22709,7 @@ document.getElementById('pl-list').addEventListener('click', function(e){
   }
   var card = e.target && e.target.closest ? e.target.closest('.pl-card') : null;
   if (!card) return;
-  var provider = card.getAttribute('data-playlist-provider') || 'netease';
+  var provider = card.getAttribute('data-playlist-provider') || 'local';
   var pid = card.getAttribute('data-playlist-id') || '';
   openPlaylistPanelDetail(provider, pid, card.getAttribute('data-playlist-title') || '');
 });
@@ -25526,7 +26349,7 @@ function applyBackgroundMediaHint() {
 }
 function relabelFxPanelControls() {
   var title = document.querySelector('#fx-panel .fx-title');
-  if (title) title.textContent = '视觉控制台';
+  if (title) title.textContent = 'DIY 视觉控制台';
   ensureLyricPrimaryControls();
   applyBackgroundMediaHint();
   var overlayGrid = document.getElementById('t-cinema');
@@ -26229,10 +27052,11 @@ function toggleFxPanel(force) {
     showToast('开启 DIY 玩家模式后可打开视觉控制台');
     return;
   }
-  var currentlyOpen = el.classList.contains('show') || el.classList.contains('peek');
+  var pinnedOpen = el.classList.contains('show');
+  var currentlyOpen = pinnedOpen || el.classList.contains('peek');
   if (peekTimers && peekTimers.fx) { clearTimeout(peekTimers.fx); peekTimers.fx = null; }
-  fxPanelPinned = false;
-  if (force === false) {
+  if (force === false || (force == null && pinnedOpen)) {
+    fxPanelPinned = false;
     el.classList.remove('show', 'peek');
     el.classList.toggle('closing', currentlyOpen);
     setTimeout(function(){ el.classList.remove('closing'); }, 280);
@@ -26240,8 +27064,15 @@ function toggleFxPanel(force) {
     if (fab) fab.classList.remove('active');
     return;
   }
-  el.classList.remove('show', 'closing');
-  setPeek(el, true, 'fx');
+  fxPanelPinned = true;
+  el.classList.remove('peek', 'closing');
+  el.classList.add('show');
+  var fabOpen = document.getElementById('fx-fab');
+  if (fabOpen) fabOpen.classList.add('active');
+  document.body.classList.remove('fullscreen-diy-peek');
+  if (!userFxArchivesHydrated) {
+    scheduleUiWarmTask(function(){ renderUserFxArchives({ force: true }); }, 40);
+  }
 }
 function resetFx() {
   var savedCam = fx.cam;
@@ -27101,21 +27932,36 @@ function bindModalBackdropClose() {
   });
 }
 function onUserBtnClick() {
-  openHomeLocalImport();
+  if (loginStatus && loginStatus.loggedIn) showUserModal();
+  else showLoginModal({ source: 'user-button' });
 }
 function hasPlatformLogin(provider) {
-  return false;
+  return provider === 'kugou' && !!(loginStatus && loginStatus.loggedIn);
 }
 function hasAnyPlatformLogin() {
-  return false;
+  return hasPlatformLogin('kugou');
 }
 function firstLoggedProvider() {
-  return 'local';
+  return hasPlatformLogin('kugou') ? 'kugou' : 'local';
 }
 async function refreshLoginStatus(force) {
   loginStatusChecked = true;
   loginStatusCheckFailed = false;
-  loginStatus = { loggedIn: false, vipType: 0, vipLevel: 'none', isVip: false, isSvip: false, vipLabel: '本地模式' };
+  var api = getDesktopWindowApi();
+  if (!api || typeof api.getKugouStatus !== 'function') {
+    loginStatus = { loggedIn: false, provider: 'kugou', vipLabel: '酷狗同步不可用' };
+    loginStatusCheckFailed = true;
+    renderUserBtn();
+    return loginStatus;
+  }
+  try {
+    var result = await api.getKugouStatus();
+    if (!result || result.ok !== true) throw new Error(result && result.error || 'KUGOU_STATUS_FAILED');
+    loginStatus = Object.assign({ provider: 'kugou', loggedIn: false, vipLabel: '酷狗歌单同步' }, result);
+  } catch (e) {
+    loginStatus = { loggedIn: false, provider: 'kugou', vipLabel: '酷狗歌单同步' };
+    loginStatusCheckFailed = true;
+  }
   renderUserBtn();
   return loginStatus;
 }
@@ -27124,62 +27970,188 @@ function renderUserBtn() {
   if (!btn) return;
   btn.classList.remove('multi-account');
   btn.classList.remove('logged-in');
-  btn.classList.add('logged-out');
-  btn.title = '导入本地音乐';
-  btn.innerHTML = '<span class="login-word">导入</span>';
+  btn.classList.toggle('logged-in', !!(loginStatus && loginStatus.loggedIn));
+  btn.classList.toggle('logged-out', !(loginStatus && loginStatus.loggedIn));
+  if (loginStatus && loginStatus.loggedIn) {
+    var label = String(loginStatus.nickname || '酷狗').trim();
+    if (label.length > 6) label = label.slice(0, 6);
+    btn.title = '酷狗账号与歌单同步';
+    btn.innerHTML = '<span class="login-word">' + escHtml(label || '酷狗') + '</span>';
+  } else {
+    btn.title = '登录酷狗音乐并同步歌单';
+    btn.innerHTML = '<span class="login-word">酷狗</span>';
+  }
   updatePlaybackQualityUi();
 }
 async function showLoginModal(opts) {
-  closeLoginModal();
-  openHomeLocalImport();
+  if (loginStatus && loginStatus.loggedIn) {
+    showUserModal();
+    return;
+  }
+  closeUserModal();
+  openGsapModal(document.getElementById('login-modal'));
+  await refreshQr();
 }
 function closeLoginModal() {
+  stopQrPoll();
   closeGsapModal(document.getElementById('login-modal'));
 }
 function setLoginProvider(provider, silent) {
+  return provider === 'kugou';
 }
 function updateLoginProviderUi() {
 }
 async function refreshQr() {
-  openHomeLocalImport();
+  var api = getDesktopWindowApi();
+  var shell = document.getElementById('kugou-qr-shell');
+  var image = document.getElementById('kugou-qr-img');
+  stopQrPoll();
+  if (shell) shell.classList.remove('ready');
+  if (image) image.removeAttribute('src');
+  setKugouQrStatus('正在获取酷狗登录二维码…', '');
+  if (!api || typeof api.startKugouLogin !== 'function') {
+    setKugouQrStatus('当前不是 Mineradio 桌面版，无法登录', 'fail');
+    return;
+  }
+  try {
+    var result = await api.startKugouLogin();
+    if (!result || result.ok !== true || !result.image) throw new Error(result && result.error || 'KUGOU_QR_FAILED');
+    if (image) image.src = result.image;
+    if (shell) shell.classList.add('ready');
+    setKugouQrStatus('请使用酷狗音乐 App 扫码', '');
+    startQrPoll();
+  } catch (e) {
+    console.warn('[KugouLoginQr]', e);
+    setKugouQrStatus('二维码加载失败，请稍后刷新', 'fail');
+  }
 }
-function startQrPoll() {}
-function stopQrPoll() {}
+function setKugouQrStatus(message, kind) {
+  var node = document.getElementById('kugou-qr-status');
+  if (!node) return;
+  node.textContent = message || '';
+  node.classList.toggle('scan', kind === 'scan');
+  node.classList.toggle('fail', kind === 'fail');
+}
+function startQrPoll() {
+  stopQrPoll();
+  kugouQrPollTimer = setInterval(checkQr, 1800);
+}
+function stopQrPoll() {
+  if (kugouQrPollTimer) clearInterval(kugouQrPollTimer);
+  kugouQrPollTimer = null;
+  kugouQrCheckBusy = false;
+}
 async function checkQr() {
+  if (kugouQrCheckBusy) return;
+  var api = getDesktopWindowApi();
+  if (!api || typeof api.checkKugouLogin !== 'function') return;
+  kugouQrCheckBusy = true;
+  try {
+    var result = await api.checkKugouLogin();
+    if (!result || result.ok !== true) throw new Error(result && result.error || 'KUGOU_QR_CHECK_FAILED');
+    if (result.status === 'authorized' && result.loggedIn) {
+      stopQrPoll();
+      loginStatusChecked = true;
+      loginStatusCheckFailed = false;
+      loginStatus = Object.assign({ provider: 'kugou', vipLabel: '酷狗歌单同步' }, result);
+      renderUserBtn();
+      setKugouQrStatus('登录成功，正在同步歌单…', 'scan');
+      await refreshUserPlaylists(true);
+      closeLoginModal();
+      showUserModal();
+      showToast('酷狗登录成功，歌单已同步');
+      return;
+    }
+    if (result.status === 'confirming') setKugouQrStatus(result.message || '已扫码，请在手机上确认', 'scan');
+    else if (result.status === 'expired') {
+      stopQrPoll();
+      setKugouQrStatus(result.message || '二维码已过期，请刷新', 'fail');
+    } else setKugouQrStatus(result.message || '请使用酷狗音乐 App 扫码', '');
+  } catch (e) {
+    console.warn('[KugouLoginCheck]', e);
+    stopQrPoll();
+    setKugouQrStatus('登录状态检查失败，请刷新二维码', 'fail');
+  } finally {
+    kugouQrCheckBusy = false;
+  }
 }
 function updateUserModalUi() {
+  var name = document.getElementById('kugou-user-name');
+  var id = document.getElementById('kugou-user-id');
+  var avatar = document.getElementById('kugou-user-avatar');
+  var sync = document.getElementById('kugou-sync-state');
+  if (name) name.textContent = loginStatus && loginStatus.nickname || '酷狗用户';
+  if (id) id.textContent = loginStatus && loginStatus.userid ? ('账号 ID · ' + loginStatus.userid) : '';
+  if (avatar) {
+    if (loginStatus && loginStatus.avatar) {
+      avatar.src = loginStatus.avatar;
+      avatar.style.opacity = '1';
+    } else {
+      avatar.removeAttribute('src');
+      avatar.style.opacity = '.22';
+    }
+  }
+  if (sync) {
+    if (kugouPlaylistsLoading) sync.textContent = '正在同步酷狗歌单…';
+    else if (kugouPlaylistsSyncedAt) sync.textContent = '已同步 ' + userPlaylists.length + ' 个歌单 · ' + new Date(kugouPlaylistsSyncedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    else sync.textContent = '歌单尚未同步';
+  }
 }
 function showUserModal() {
-  openHomeLocalImport();
+  if (!loginStatus || !loginStatus.loggedIn) {
+    showLoginModal({ source: 'account' });
+    return;
+  }
+  closeLoginModal();
+  updateUserModalUi();
+  openGsapModal(document.getElementById('user-modal'));
 }
 function closeUserModal() { closeGsapModal(document.getElementById('user-modal')); }
 function setActiveAccountProvider(provider) {
-  openHomeLocalImport();
+  return provider === 'kugou';
 }
 function enableDualAccountView() {
-  openHomeLocalImport();
+  showLoginModal({ source: 'account' });
 }
 function requestDualLoginMode() {
   enableDualAccountView();
 }
 function openProviderLogin(provider) {
   closeUserModal();
-  closeLoginModal();
-  openHomeLocalImport();
+  showLoginModal({ source: provider || 'kugou' });
 }
 async function logoutActiveAccount() {
+  var api = getDesktopWindowApi();
+  try {
+    if (api && typeof api.logoutKugou === 'function') await api.logoutKugou();
+  } catch (e) {
+    console.warn('[KugouLogout]', e);
+  }
   doLogout();
+  showToast('已退出酷狗音乐登录');
 }
 async function doLogout() {
-  loginStatus = { loggedIn: false };
+  loginStatus = { loggedIn: false, provider: 'kugou', vipLabel: '酷狗歌单同步' };
   userPlaylists = [];
+  kugouPlaylistsSyncedAt = 0;
   likedSongMap = {};
   closeCollectModal();
   updateLikeButtons();
   safeRenderQueuePanel('logout', { scrollCurrent: miniQueueOpen });
+  playlistPanelLastDomSignature = '';
+  renderLocalLibraryPlaylistPanel({ animate: true });
   renderUserBtn();
   safeShelfRebuild('logout');
   closeUserModal();
+}
+async function syncKugouPlaylistsFromModal() {
+  await refreshUserPlaylists(true);
+  updateUserModalUi();
+  if (loginStatus && loginStatus.loggedIn) {
+    closeUserModal();
+    safeSwitchPlaylistTab('playlists', 'kugou-sync');
+    togglePlaylistPanel(true);
+  }
 }
 var startupLoginGuideShown = false;
 var loginGuideAnimating = false;
@@ -30142,6 +31114,8 @@ bindFxPanel();
 applySavedLyricPaletteState();
 bindQualityControl();
 bindVolumeControls();
+initHomeClock();
+initHomeWeather();
 initControlGlassSurface();
 bindPlayerControlAnimations();
 scheduleUiWarmTask(function(){
@@ -30174,6 +31148,11 @@ if (LOCAL_ONLY_MODE) {
   homeDiscoverState.playlists = [];
   homeDiscoverState.podcasts = [];
   renderUserBtn();
+  setTimeout(function(){
+    refreshLoginStatus().then(function(status){
+      if (status && status.loggedIn) refreshUserPlaylists(false);
+    });
+  }, 450);
   if (!document.body.classList.contains('splash-active')) updateEmptyHomeVisibility({ forceLoad: false });
 }
 var collectNameInput = document.getElementById('collect-new-name');
@@ -30199,7 +31178,6 @@ updateCustomCoverButton();
 updateCustomLyricControls();
 updateLikeButtons();
 if (LOCAL_ONLY_MODE) scheduleSavedLocalMusicFolderRestore(700);
-setTimeout(initUpdatePreview, LOCAL_ONLY_MODE ? 12000 : 9000);
 
 // ============================================================
 //  主循环

--- a/public/mini-player-compact.html
+++ b/public/mini-player-compact.html
@@ -33,7 +33,9 @@
       background: rgba(9, 12, 15, 0.97);
       box-shadow: 0 10px 28px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.08);
       -webkit-app-region: drag;
+      transition: opacity 180ms ease, transform 180ms ease, filter 180ms ease;
     }
+    body.dismissing .mini-shell { opacity: 0; transform: translateY(7px) scale(0.985); filter: blur(3px); }
     .meta {
       min-width: 0;
       flex: 1 1 auto;
@@ -103,17 +105,28 @@
     .pause-icon { display: none; }
     body[data-playing="true"] .play-icon { display: none; }
     body[data-playing="true"] .pause-icon { display: block; }
-    .restore {
+    .window-actions {
       flex: 0 0 18px;
+      align-self: stretch;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      align-items: center;
+      -webkit-app-region: no-drag;
+    }
+    .window-action {
       width: 18px;
       height: 18px;
-      align-self: flex-start;
-      margin: -2px -2px 0 0;
       border-color: transparent;
       background: transparent;
       color: rgba(225, 232, 235, 0.46);
     }
-    .restore svg { width: 11px; height: 11px; }
+    .window-action svg { width: 11px; height: 11px; }
+    .close-mini:hover:not(:disabled) {
+      border-color: rgba(255, 102, 122, 0.34);
+      background: rgba(255, 82, 108, 0.14);
+      color: #ffd7de;
+    }
     @media (prefers-reduced-motion: reduce) {
       button { transition: none; }
     }
@@ -137,9 +150,14 @@
         <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="m6 18 8.5-6L6 6v12zM16 6v12h2V6z"/></svg>
       </button>
     </div>
-    <button id="restore" class="restore" type="button" title="返回主界面" aria-label="返回主界面">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8 3H3v5M16 3h5v5M8 21H3v-5M16 21h5v-5"/></svg>
-    </button>
+    <div class="window-actions" aria-label="小窗操作">
+      <button id="restore" class="window-action restore" type="button" title="返回主界面" aria-label="返回主界面">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8 3H3v5M16 3h5v5M8 21H3v-5M16 21h5v-5"/></svg>
+      </button>
+      <button id="close-mini" class="window-action close-mini" type="button" title="关闭小窗" aria-label="关闭小窗">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="m7 7 10 10M17 7 7 17"/></svg>
+      </button>
+    </div>
   </main>
   <script>
     'use strict';
@@ -150,14 +168,38 @@
     var miniState = { title:'Mineradio', artist:'', playing:false, hasTrack:false };
     var renderedPlaying = null;
     var renderedHasTrack = null;
+    var dismissVisualTimer = 0;
 
     function sendCommand(action) {
-      if (!window.miniPlayer || typeof window.miniPlayer.command !== 'function') return;
-      window.miniPlayer.command(action).catch(function(){});
+      if (!window.miniPlayer || typeof window.miniPlayer.command !== 'function') return Promise.resolve({ ok:false });
+      return window.miniPlayer.command(action).catch(function(){ return { ok:false }; });
+    }
+
+    function runTransportCommand(action) {
+      var previousPlaying = miniState.playing === true;
+      if (action === 'toggle-play') applyState({ playing: !previousPlaying });
+      sendCommand(action).then(function(result){
+        if (!result || result.ok !== true) {
+          if (action === 'toggle-play') applyState({ playing: previousPlaying });
+          return;
+        }
+        if (action === 'toggle-play' && typeof result.expectedPlaying === 'boolean') {
+          applyState({ playing: result.expectedPlaying });
+        }
+        var dismissAfterMs = Math.max(0, Number(result.dismissAfterMs) || 0);
+        if (dismissAfterMs > 0) {
+          if (dismissVisualTimer) clearTimeout(dismissVisualTimer);
+          dismissVisualTimer = setTimeout(function(){
+            dismissVisualTimer = 0;
+            document.body.classList.add('dismissing');
+          }, Math.max(0, dismissAfterMs - 190));
+        }
+      });
     }
 
     function applyState(patch) {
       patch = patch || {};
+      if (document.body.classList.contains('dismissing')) document.body.classList.remove('dismissing');
       miniState = Object.assign({}, miniState, patch);
       var next = miniState;
       var hasTrack = next.hasTrack === true;
@@ -180,10 +222,11 @@
       }
     }
 
-    document.getElementById('previous').addEventListener('click', function(){ sendCommand('previous'); });
-    playButton.addEventListener('click', function(){ sendCommand('toggle-play'); });
-    document.getElementById('next').addEventListener('click', function(){ sendCommand('next'); });
+    document.getElementById('previous').addEventListener('click', function(){ runTransportCommand('previous'); });
+    playButton.addEventListener('click', function(){ runTransportCommand('toggle-play'); });
+    document.getElementById('next').addEventListener('click', function(){ runTransportCommand('next'); });
     document.getElementById('restore').addEventListener('click', function(){ sendCommand('restore'); });
+    document.getElementById('close-mini').addEventListener('click', function(){ sendCommand('close'); });
     document.getElementById('mini-shell').addEventListener('dblclick', function(event){
       if (!event.target.closest('button')) sendCommand('restore');
     });

--- a/public/mini-player.html
+++ b/public/mini-player.html
@@ -33,7 +33,9 @@
       background: rgba(9, 12, 15, 0.96);
       box-shadow: 0 14px 38px rgba(0, 0, 0, 0.42), inset 0 1px 0 rgba(255, 255, 255, 0.08);
       -webkit-app-region: drag;
+      transition: opacity 180ms ease, transform 180ms ease, filter 180ms ease;
     }
+    body.dismissing .mini-shell { opacity: 0; transform: translateY(8px) scale(0.985); filter: blur(3px); }
     .cover {
       position: relative;
       flex: 0 0 54px;
@@ -135,17 +137,28 @@
     .pause-icon { display: none; }
     body[data-playing="true"] .play-icon { display: none; }
     body[data-playing="true"] .pause-icon { display: block; }
-    .restore {
+    .window-actions {
       flex: 0 0 24px;
+      align-self: stretch;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      align-items: center;
+      -webkit-app-region: no-drag;
+    }
+    .window-action {
       width: 24px;
       height: 24px;
-      align-self: flex-start;
-      margin: -1px -1px 0 0;
       border-color: transparent;
       background: transparent;
       color: rgba(225, 232, 235, 0.48);
     }
-    .restore svg { width: 13px; height: 13px; }
+    .window-action svg { width: 13px; height: 13px; }
+    .close-mini:hover:not(:disabled) {
+      border-color: rgba(255, 102, 122, 0.34);
+      background: rgba(255, 82, 108, 0.14);
+      color: #ffd7de;
+    }
     @media (prefers-reduced-motion: reduce) {
       .cover img, button { transition: none; }
     }
@@ -173,9 +186,14 @@
         <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="m6 18 8.5-6L6 6v12zM16 6v12h2V6z"/></svg>
       </button>
     </div>
-    <button id="restore" class="restore" type="button" title="返回主界面" aria-label="返回主界面">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8 3H3v5M16 3h5v5M8 21H3v-5M16 21h5v-5"/></svg>
-    </button>
+    <div class="window-actions" aria-label="小窗操作">
+      <button id="restore" class="window-action restore" type="button" title="返回主界面" aria-label="返回主界面">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8 3H3v5M16 3h5v5M8 21H3v-5M16 21h5v-5"/></svg>
+      </button>
+      <button id="close-mini" class="window-action close-mini" type="button" title="关闭小窗" aria-label="关闭小窗">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><path d="m7 7 10 10M17 7 7 17"/></svg>
+      </button>
+    </div>
   </main>
   <script>
     'use strict';
@@ -189,10 +207,33 @@
     var miniState = { title:'Mineradio', artist:'', cover:'', playing:false, hasTrack:false };
     var renderedPlaying = null;
     var renderedHasTrack = null;
+    var dismissVisualTimer = 0;
 
     function sendCommand(action) {
-      if (!window.miniPlayer || typeof window.miniPlayer.command !== 'function') return;
-      window.miniPlayer.command(action).catch(function(){});
+      if (!window.miniPlayer || typeof window.miniPlayer.command !== 'function') return Promise.resolve({ ok:false });
+      return window.miniPlayer.command(action).catch(function(){ return { ok:false }; });
+    }
+
+    function runTransportCommand(action) {
+      var previousPlaying = miniState.playing === true;
+      if (action === 'toggle-play') applyState({ playing: !previousPlaying });
+      sendCommand(action).then(function(result){
+        if (!result || result.ok !== true) {
+          if (action === 'toggle-play') applyState({ playing: previousPlaying });
+          return;
+        }
+        if (action === 'toggle-play' && typeof result.expectedPlaying === 'boolean') {
+          applyState({ playing: result.expectedPlaying });
+        }
+        var dismissAfterMs = Math.max(0, Number(result.dismissAfterMs) || 0);
+        if (dismissAfterMs > 0) {
+          if (dismissVisualTimer) clearTimeout(dismissVisualTimer);
+          dismissVisualTimer = setTimeout(function(){
+            dismissVisualTimer = 0;
+            document.body.classList.add('dismissing');
+          }, Math.max(0, dismissAfterMs - 190));
+        }
+      });
     }
 
     function setCover(src) {
@@ -209,6 +250,7 @@
 
     function applyState(patch) {
       patch = patch || {};
+      if (document.body.classList.contains('dismissing')) document.body.classList.remove('dismissing');
       miniState = Object.assign({}, miniState, patch);
       var next = miniState;
       var hasTrack = next.hasTrack === true;
@@ -243,10 +285,11 @@
         cover.removeAttribute('src');
       }
     });
-    document.getElementById('previous').addEventListener('click', function(){ sendCommand('previous'); });
-    playButton.addEventListener('click', function(){ sendCommand('toggle-play'); });
-    document.getElementById('next').addEventListener('click', function(){ sendCommand('next'); });
+    document.getElementById('previous').addEventListener('click', function(){ runTransportCommand('previous'); });
+    playButton.addEventListener('click', function(){ runTransportCommand('toggle-play'); });
+    document.getElementById('next').addEventListener('click', function(){ runTransportCommand('next'); });
     document.getElementById('restore').addEventListener('click', function(){ sendCommand('restore'); });
+    document.getElementById('close-mini').addEventListener('click', function(){ sendCommand('close'); });
     document.getElementById('mini-shell').addEventListener('dblclick', function(event){
       if (!event.target.closest('button')) sendCommand('restore');
     });


### PR DESCRIPTION
## What changed

- Add Kugou QR login, encrypted local session storage, playlist sync, online search, quality-aware stream resolution, and synchronized lyrics.
- Improve track identity matching using title, artist, album, duration, and returned filename checks to reduce wrong-song playback.
- Refine playback quality, DIY/player controls, lyric behavior, and homepage interactions.
- Add a real close action for the mini player and prevent it from reopening after the user closes it.
- Simplify the homepage by removing the local-library block, weather playlist recommendation, and seconds display.
- Add remembered city weather with current temperature, condition, feels-like temperature, daily range, wind, humidity, and air quality.

## Why

The existing player could resolve ambiguous online tracks to the wrong recording, lacked a Kugou account/search workflow, and had several desktop interaction issues. The live weather endpoint also required a main-process request path because the detailed endpoint does not expose browser CORS headers.

## Validation

- `node --check` passed for desktop main/preload, mini-player preload, Kugou sync, and server scripts.
- All inline scripts in the main and mini-player HTML files parsed successfully.
- `git diff --check` passed apart from the existing Windows line-ending notice.
- `npm run build:win` completed and generated both NSIS and portable ZIP artifacts.
- Runtime UI checks confirmed current weather fields and mini-player close behavior without automatic reopening.
