### PR TITLE
docs: 项目介绍补上 v1.8.3 的歌词能力

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 - 支持音乐文件夹自动监控：新增、删除、改标签、换封面自动同步，不必重启。
 - 支持 MP3 / MP2 / FLAC / M4A / M4B / WAV / OGG / OGA / AAC / Opus / WebM / WebA / AIFF / APE / DSD(.dsf) 播放。
 - 支持同名 `.lrc` / `.txt` / `.srt` / `.vtt` / `.ass` / `.yrc` / `.krc` / `.qrc` / `.ttml` 歌词。
+- 支持加密歌词：KRC（`krc1`）与 QRC（十六进制文本与二进制密文两种形态）都能直接读。
+- 支持一首歌配多份同名歌词时按格式优先级自动挑，也可以自己挑一份并记住。
+- 支持歌词编码自动识别：UTF-8 / UTF-16 / GB18030 / Big5 / Shift_JIS / EUC-KR / Windows-1252。
 - 支持 MP3 / FLAC / OGG / OPUS / WAV / APE / DSF 内嵌歌词标签，包括带时间轴的 LRC 歌词。
 - 支持同目录封面图片和音频内嵌封面。
 - 移除本地节奏分析环节。
@@ -42,7 +45,12 @@
 
 ### 📝 歌词功能
 - ✅ 同名 `.lrc` / `.txt` / `.srt` / `.vtt` / `.ass` / `.yrc` / `.krc` / `.qrc` / `.ttml` 歌词文件
-- ✅ 逐字歌词：YRC（网易云）/ KRC（酷狗，含 `krc1` 加密二进制）/ QRC（QQ 音乐，含 XML 容器）/ TTML（Apple Music 一族）
+- ✅ 逐字歌词：YRC（网易云）/ KRC（酷狗，含 `krc1` 加密二进制）/ QRC（QQ 音乐，含 XML 容器与加密载体）/ TTML（Apple Music 一族）
+- ✅ QRC 加密歌词：接口原样落盘的十六进制文本与直接写成二进制的密文两种形态都收，识别只看内容特征，后缀被改过也认得出来
+- ✅ 同名多份歌词按格式优先级自动挑：逐字时间轴（`.qrc` / `.krc` / `.ttml` / `.yrc`）> 逐行 `.lrc` > 字幕（`.ass` / `.srt` / `.vtt`）> `.txt`
+- ✅ 同名多份歌词也能自己挑：自定义歌词弹窗里列出候选（写着路径与格式），选择会记住，下次重新导入同一批文件仍用你挑的那一份
+- ✅ 歌词编码自动识别：UTF-8 / UTF-16LE / UTF-16BE（含无 BOM）/ GB18030 / Big5 / Shift_JIS / EUC-KR / Windows-1252
+- ✅ 歌词时间轴兼容在野写法：`[offset:±N]` 全局偏移、`[mm:ss:cc]`、`[hh:mm:ss.fff]`，小数位按实际位数换算
 - ✅ MP3 / FLAC / OGG / OPUS / WAV / APE / DSF 内嵌歌词标签
 - ✅ 带时间轴的 LRC 格式
 - ✅ 歌词翻译自动识别和显示
@@ -260,7 +268,10 @@ npm test
 
 ### 如何添加歌词？
 - 将 `.lrc` / `.txt` / `.srt` / `.vtt` / `.ass` / `.yrc` / `.krc` / `.qrc` / `.ttml` 歌词文件放在音乐文件同目录，保持文件名一致
-- 逐字歌词直接认：YRC、KRC（含 `krc1` 加密二进制）、QRC（含 `<Lyric_1 LyricContent="…">` XML 容器）、TTML
+- 逐字歌词直接认：YRC、KRC（含 `krc1` 加密二进制）、QRC（含 `<Lyric_1 LyricContent="…">` XML 容器与加密载体）、TTML
+- 加密的 QRC 不用先解密：十六进制文本与二进制密文两种形态都能直接放进去，识别看内容不看后缀
+- 一首歌配了多份同名歌词时，默认按格式优先级挑（逐字 > `.lrc` > 字幕 > `.txt`）；想换成另一份就在自定义歌词弹窗里点候选按钮，选择会被记住
+- 歌词文件不是 UTF-8 也没关系：UTF-16、GB18030、Big5、Shift_JIS、EUC-KR、Windows-1252 会自动识别，合法的 UTF-8 一律不重猜
 - MP3 / FLAC / OGG / OPUS / WAV / APE / DSF 文件可直接使用内嵌歌词标签（如 FLAC/OGG 的 `LYRICS`、MP3 的 `USLT`）
 
 ### 封面图片如何加载？

--- a/README_EN.md
+++ b/README_EN.md
@@ -15,7 +15,10 @@ Original project: [XxHuberrr/Mineradio](https://github.com/XxHuberrr/Mineradio)
 - Automatic music folder monitoring: new files are indexed, deleted files are pruned, tag and cover edits refresh on their own, no restart required.
 - Support for MP3 / MP2 / FLAC / M4A / M4B / WAV / OGG / OGA / AAC / Opus / WebM / WebA / AIFF / APE / DSD(.dsf) playback.
 - Support for `.lrc` / `.txt` / `.srt` / `.vtt` / `.ass` / `.yrc` / `.krc` / `.qrc` / `.ttml` lyrics files with matching names.
-- Word-by-word lyrics from YRC, KRC (including `krc1` encrypted binaries), QRC (including the XML container) and TTML.
+- Word-by-word lyrics from YRC, KRC (including `krc1` encrypted binaries), QRC (including the XML container and encrypted payloads) and TTML.
+- Encrypted QRC lyrics are read directly, both as the hex text the API returns and as raw binary ciphertext.
+- When one track has several same-named lyrics files, the best one is picked by format priority — and you can pick a different one yourself, which is remembered.
+- Automatic lyrics encoding detection: UTF-8 / UTF-16 / GB18030 / Big5 / Shift_JIS / EUC-KR / Windows-1252.
 - Support for MP3 / FLAC / OGG / OPUS / WAV / APE / DSF embedded lyrics tags, including timestamped LRC lyrics.
 - Support for automatic lyrics translation recognition and display.
 - Support for cover images in the same directory and embedded audio covers.
@@ -58,7 +61,12 @@ Build artifacts are located in `dist/`.
 
 ### Lyrics Features
 - Matching LRC/TXT/SRT/WebVTT/ASS/YRC/KRC/QRC/TTML lyrics files
-- Word-by-word lyrics: YRC (NetEase), KRC (Kugou, plaintext and `krc1` encrypted binary), QRC (QQ Music, XML container and bare body), TTML (the Apple Music family)
+- Word-by-word lyrics: YRC (NetEase), KRC (Kugou, plaintext and `krc1` encrypted binary), QRC (QQ Music, XML container, bare body and encrypted payload), TTML (the Apple Music family)
+- Encrypted QRC: both the hex text the API returns verbatim and raw binary ciphertext are accepted; detection looks at content, not the file extension, so renamed files still work
+- Several same-named lyrics files are ranked by format: word-level timing (`.qrc` / `.krc` / `.ttml` / `.yrc`) > line-level `.lrc` > subtitles (`.ass` / `.srt` / `.vtt`) > `.txt`
+- You can also pick the candidate yourself: the custom-lyrics dialog lists every match with its path and format, and your choice survives a re-import of the same files
+- Automatic encoding detection: UTF-8 / UTF-16LE / UTF-16BE (with or without BOM) / GB18030 / Big5 / Shift_JIS / EUC-KR / Windows-1252, and valid UTF-8 is never second-guessed
+- Timeline quirks handled: `[offset:±N]` global shift, `[mm:ss:cc]`, `[hh:mm:ss.fff]`, and fractions scaled by their actual digit count
 - Matching JPG/JPEG/JPE/JFIF/PNG/WebP/AVIF/GIF/BMP/SVG cover files
 - MP3 / FLAC / OGG / OPUS / WAV / APE / DSF embedded lyrics tags
 - Automatic lyrics translation recognition


### PR DESCRIPTION
只改两份 README，代码与版本号未动。

变更日志里已经有 `v1.8.3`，但「功能特性」和常见问题还停在 `v1.8.2` 的描述上 —— 光看功能列表会以为加密 QRC、多份歌词挑选、编码识别这些都还没有。这次把五项补进两份 README 的顶部要点、歌词功能小节与 FAQ：

- **QRC 加密歌词**：十六进制文本与二进制密文两种载体都收，识别只看内容特征，后缀被改过也认得出来
- **同名多份歌词按格式优先级自动挑**：逐字时间轴（`.qrc` / `.krc` / `.ttml` / `.yrc`）> 逐行 `.lrc` > 字幕（`.ass` / `.srt` / `.vtt`）> `.txt`
- **同名多份歌词可手动挑**：自定义歌词弹窗里列出候选，选择会记住，重新导入仍用你挑的那一份
- **歌词编码自动识别**：UTF-16LE / UTF-16BE（含无 BOM）/ GB18030 / Big5 / Shift_JIS / EUC-KR / Windows-1252，合法 UTF-8 一律不重猜
- **时间轴在野写法兼容**：`[offset:±N]` 全局偏移、`[mm:ss:cc]`、`[hh:mm:ss.fff]`，小数位按实际位数换算

写进去的两处清单已经对着源码核过，不是照抄发布说明：`LOCAL_LYRIC_FORMAT_RANK`（`public/app.js:28089`）确实是 `qrc/krc/ttml/yrc: 0, lrc: 1, ass/srt/vtt: 2, txt: 3`，候选编码表（`public/app.js:28464`）确实是 `gb18030` → `big5` → `shift_jis` → `euc-kr` → `windows-1252`。

两份文件都无 BOM、无 CRLF、无 U+FFFD。
