### PR TITLE
fix(fullscreen): 全屏进入/退出对齐上游 XxHuberrr/Mineradio

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -182,6 +182,8 @@ const miniPlayerRecoverySession = new MiniPlayerRecoverySession({
 const miniPlayerStateCache = new MiniPlayerStateCache(miniPlayerEnabled);
 let htmlFullscreenActive = false;
 let windowFullscreenActive = false;
+let mainWindowFullscreenVisibilityTimer = null;
+let mainWindowIntentionalHide = false;
 let mainWindowStateTimer = null;
 let tray = null;
 let closeToTrayEnabled = true;
@@ -1587,6 +1589,7 @@ function focusMainWindow() {
   if (!mainWindow || mainWindow.isDestroyed()) return false;
   miniPlayerActive = false;
   hideMiniPlayerWindow();
+  mainWindowIntentionalHide = false;
   if (mainWindow.isMinimized()) mainWindow.restore();
   if (!mainWindow.isVisible()) mainWindow.show();
   mainWindow.focus();
@@ -2210,19 +2213,34 @@ function getWindowedBounds(win) {
   };
 }
 
+/**
+ * 全屏期间锁住窗口尺寸，退出全屏时再放开。
+ * 与上游 XxHuberrr/Mineradio 的 `setMainWindowFullscreenResizeGuard` 行为一致：
+ * 原生全屏时窗口仍可调整大小，Windows 会把全屏尺寸当成一次用户 resize 反复回灌，
+ * 导致边界还原与原生全屏互相拉扯。
+ * @param {Electron.BrowserWindow} win 当前主窗口。
+ * @param {boolean} fullscreen 目标是否为全屏状态。
+ * @returns {void}
+ */
+function setMainWindowFullscreenResizeGuard(win, fullscreen) {
+  if (!win || win.isDestroyed()) return;
+  const shouldResize = !fullscreen;
+  try {
+    if (typeof win.isResizable === 'function' && win.isResizable() === shouldResize) return;
+    win.setResizable(shouldResize);
+  } catch (e) {
+    console.warn('[WindowResizeGuard]', fullscreen ? 'fullscreen-lock' : 'windowed-restore', e.message || e);
+  }
+}
+
 function applyWindowedBounds(win) {
   if (!win || win.isDestroyed()) return;
+  setMainWindowFullscreenResizeGuard(win, false);
   if (win.isMaximized()) win.unmaximize();
   const display = screen.getDisplayMatching(win.getBounds()) || screen.getPrimaryDisplay();
   const minimum = windowedMinimumSize(display);
   win.setMinimumSize(minimum.width, minimum.height);
-  const target = getWindowedBounds(win);
-  const current = win.getBounds();
-  // 退出全屏时 leave-full-screen 与 exitFullscreenToWindow 都会安排还原，
-  // 边界已经到位就不要再 setBounds：多一次尺寸跳变，渲染层就多压一轮全屏遮罩。
-  const settled = current.x === target.x && current.y === target.y
-    && current.width === target.width && current.height === target.height;
-  if (!settled) win.setBounds(target, false);
+  win.setBounds(getWindowedBounds(win), false);
   sendWindowState(win);
 }
 
@@ -2267,29 +2285,22 @@ function keepMainWindowInsideDisplay(win, options = {}) {
 
 /**
  * 退出主窗口全屏并恢复居中的普通窗口尺寸。
+ * 与上游 XxHuberrr/Mineradio 的 `exitFullscreenToWindow` 一致：只调一次原生退出，
+ * 边界还原交给权威的 leave-full-screen 事件。这里再补一次延迟还原会变成 move/resize 风暴。
  * @param {Electron.BrowserWindow} win 当前主窗口。
  * @returns {void}
  */
 function exitFullscreenToWindow(win) {
   if (!win || win.isDestroyed()) return;
-  const wasFullscreen = win.isFullScreen() || windowFullscreenActive;
   windowFullscreenActive = false;
 
-  if (!wasFullscreen) {
+  if (!win.isFullScreen()) {
     applyWindowedBounds(win);
     return;
   }
 
-  let applied = false;
-  const applyOnce = () => {
-    if (applied || !win || win.isDestroyed() || win.isFullScreen()) return;
-    applied = true;
-    applyWindowedBounds(win);
-  };
-
-  win.once('leave-full-screen', () => setTimeout(applyOnce, 50));
+  setMainWindowFullscreenResizeGuard(win, false);
   win.setFullScreen(false);
-  setTimeout(applyOnce, 500);
 }
 
 /**
@@ -2303,7 +2314,11 @@ function toggleFullscreen(win) {
     exitFullscreenToWindow(win);
     return;
   }
+  // 上游在置位全屏标记之后调 ensureMainWindowInsideDisplay；本仓库的同名工具
+  // keepMainWindowInsideDisplay 会因为全屏标记直接返回，所以必须放在置位之前。
+  keepMainWindowInsideDisplay(win);
   windowFullscreenActive = true;
+  setMainWindowFullscreenResizeGuard(win, true);
   win.setFullScreen(true);
   sendWindowState(win);
 }
@@ -5289,6 +5304,60 @@ async function handleWallpaperStateUpdate(_event, payload) {
 
 ipcMain.handle('mineradio-wallpaper-update', trustedMainFrameHandler(handleWallpaperStateUpdate));
 
+// 全屏可见性看门狗。移植上游 XxHuberrr/Mineradio 的
+// startMainWindowFullscreenVisibilityGuard / restoreUnexpectedFullscreenVisibility：
+// 全屏状态还在、窗口却已经不可见，用户看到的就是一整块黑屏，而且不会自己回来。
+const FULLSCREEN_VISIBILITY_CHECK_MS = 5000;
+
+/**
+ * 停掉全屏可见性看门狗。
+ * @returns {void}
+ */
+function clearMainWindowFullscreenVisibilityGuard() {
+  if (mainWindowFullscreenVisibilityTimer) clearInterval(mainWindowFullscreenVisibilityTimer);
+  mainWindowFullscreenVisibilityTimer = null;
+}
+
+/**
+ * 判断主窗口是否处于「仍在全屏但已经不可见」的异常状态。
+ * 用户自己收进托盘、最小化和退出流程都不算异常，不能把窗口抢回前台。
+ * @param {Electron.BrowserWindow} win 当前主窗口。
+ * @returns {boolean} 需要强制恢复可见性时返回 true。
+ */
+function shouldRestoreUnexpectedFullscreenVisibility(win) {
+  if (!win || win.isDestroyed() || appQuitting || mainWindowIntentionalHide) return false;
+  if (!win.isFullScreen() || win.isMinimized() || win.isVisible()) return false;
+  return true;
+}
+
+/**
+ * 把异常隐藏的全屏主窗口重新显示出来。
+ * @param {Electron.BrowserWindow} win 当前主窗口。
+ * @param {string} [reason] 触发原因，仅用于日志。
+ * @returns {boolean} 实际执行了恢复时返回 true。
+ */
+function restoreUnexpectedFullscreenVisibility(win, reason = 'fullscreen-visibility-guard') {
+  if (!shouldRestoreUnexpectedFullscreenVisibility(win)) return false;
+  console.warn('[WindowRecovery] restoring unexpectedly hidden fullscreen window:', reason);
+  try { win.showInactive(); } catch (_) { try { win.show(); } catch (_) { } }
+  sendWindowState(win);
+  return true;
+}
+
+/**
+ * 进入全屏后启动可见性看门狗，退出全屏时由调用方清掉。
+ * @param {Electron.BrowserWindow} win 当前主窗口。
+ * @returns {void}
+ */
+function startMainWindowFullscreenVisibilityGuard(win) {
+  clearMainWindowFullscreenVisibilityGuard();
+  if (!win || win.isDestroyed()) return;
+  mainWindowFullscreenVisibilityTimer = setInterval(() => {
+    restoreUnexpectedFullscreenVisibility(win, 'fullscreen-watchdog');
+  }, FULLSCREEN_VISIBILITY_CHECK_MS);
+  if (typeof mainWindowFullscreenVisibilityTimer.unref === 'function') mainWindowFullscreenVisibilityTimer.unref();
+}
+
 // 主窗口绘制恢复。迷你播放器早就有 did-fail-load / render-process-gone 兜底，主窗口一直没有：
 // 主渲染进程一崩，`transparent: true` 的无边框窗口就只剩一片全黑，而且永远不会自己回来。
 const MAIN_WINDOW_SHOW_WATCHDOG_MS = 6000;
@@ -5395,6 +5464,8 @@ function scheduleMainWindowPaintRecovery(win, reason) {
 async function createWindow() {
   htmlFullscreenActive = false;
   windowFullscreenActive = false;
+  mainWindowIntentionalHide = false;
+  clearMainWindowFullscreenVisibilityGuard();
   const preferredPort = resolvePreferredServerPort({
     instanceId: INSTANCE_ID,
     port: process.env.MINERADIO_PORT,
@@ -5556,6 +5627,9 @@ async function createWindow() {
     if (canKeepRunning) {
       event.preventDefault();
       miniPlayerActive = !!miniPlayerEnabled;
+      // 用户主动收进托盘：全屏可见性看门狗不能把窗口再抢回前台。
+      mainWindowIntentionalHide = true;
+      clearMainWindowFullscreenVisibilityGuard();
       mainWindow.hide();
       if (miniPlayerActive) showMiniPlayerWindow();
       sendWindowState(mainWindow);
@@ -5571,6 +5645,7 @@ async function createWindow() {
       mainWindowStateTimer = null;
     }
     clearMainWindowShowWatchdog();
+    clearMainWindowFullscreenVisibilityGuard();
     if (mainWindowPaintRecoveryTimer) {
       clearTimeout(mainWindowPaintRecoveryTimer);
       mainWindowPaintRecoveryTimer = null;
@@ -5582,21 +5657,27 @@ async function createWindow() {
   });
   mainWindow.on('enter-full-screen', () => {
     windowFullscreenActive = true;
+    setMainWindowFullscreenResizeGuard(mainWindow, true);
     sendWindowState(mainWindow);
+    startMainWindowFullscreenVisibilityGuard(mainWindow);
   });
   mainWindow.on('leave-full-screen', () => {
     windowFullscreenActive = false;
+    setMainWindowFullscreenResizeGuard(mainWindow, false);
+    clearMainWindowFullscreenVisibilityGuard();
     // 先把"已退出全屏"推给渲染层，别等 50ms 后的边界还原顺带通知，
-    // 否则渲染层的全屏遮罩要多黑这一段才知道可以回亮。
+    // 否则渲染层的全屏遮罩要多黑这一段才知道可以回亮。上游没有这层遮罩，所以没有这一步。
     sendWindowState(mainWindow);
     setTimeout(() => applyWindowedBounds(mainWindow), 50);
   });
   mainWindow.on('enter-html-full-screen', () => {
     htmlFullscreenActive = true;
+    setMainWindowFullscreenResizeGuard(mainWindow, true);
     sendWindowState(mainWindow);
   });
   mainWindow.on('leave-html-full-screen', () => {
     htmlFullscreenActive = false;
+    setMainWindowFullscreenResizeGuard(mainWindow, false);
     sendWindowState(mainWindow);
     setTimeout(() => applyWindowedBounds(mainWindow), 50);
   });
@@ -5662,6 +5743,8 @@ if (!gotSingleInstanceLock) {
     // 主窗口是透明无边框的，合成表面丢了之后 Chromium 不一定自己重新出图 —— 那就是一片全黑。
     powerMonitor.on('resume', () => nudgeMainWindowRepaint('system-resume'));
     powerMonitor.on('unlock-screen', () => nudgeMainWindowRepaint('screen-unlock'));
+    powerMonitor.on('resume', () => restoreUnexpectedFullscreenVisibility(mainWindow, 'system-resume'));
+    powerMonitor.on('unlock-screen', () => restoreUnexpectedFullscreenVisibility(mainWindow, 'screen-unlock'));
     createTray();
     await createWindow();
   });

--- a/tests/fullscreen-exit-transition.test.js
+++ b/tests/fullscreen-exit-transition.test.js
@@ -184,28 +184,38 @@ test('全屏切换的补偿刷新会去重，避免反复重建渲染缓冲', ()
 
 test('退出全屏只做一次窗口边界还原，并立刻把状态推给渲染层', () => {
   const main = readProjectFile('desktop/main.js');
-  const applyBounds = readSourceBlock(main, 'function applyWindowedBounds(', 'function keepMainWindowInsideDisplay(');
-  assert.match(applyBounds, /const settled = current\.x === target\.x/);
-  assert.match(applyBounds, /if \(!settled\) win\.setBounds\(target, false\);/);
+  // 与上游 XxHuberrr/Mineradio 对齐：边界还原只由权威的 leave-full-screen 事件安排一次，
+  // exitFullscreenToWindow 里不再挂 once('leave-full-screen') 和 500ms 兜底。
+  const exitFullscreen = readSourceBlock(main, 'function exitFullscreenToWindow(', 'function toggleFullscreen(');
+  assert.doesNotMatch(exitFullscreen, /once\('leave-full-screen'/);
+  assert.doesNotMatch(exitFullscreen, /setTimeout/);
+  assert.match(exitFullscreen, /setMainWindowFullscreenResizeGuard\(win, false\);\s*\n\s*win\.setFullScreen\(false\);/);
 
+  const applyBounds = readSourceBlock(main, 'function applyWindowedBounds(', '/**');
+  assert.match(applyBounds, /setMainWindowFullscreenResizeGuard\(win, false\);/);
+  assert.match(applyBounds, /win\.setBounds\(getWindowedBounds\(win\), false\);/);
+  assert.doesNotMatch(applyBounds, /const settled =/, '单航班还原之后不再需要 settled 短路');
+
+  // 本仓库比上游多一层全屏遮罩，所以状态要立刻推给渲染层，不能等 50ms 后的边界还原顺带通知。
   const leaveFullscreen = readSourceBlock(main, "mainWindow.on('leave-full-screen'", '});');
   assert.match(leaveFullscreen, /sendWindowState\(mainWindow\);/);
   const leaveHtmlFullscreen = readSourceBlock(main, "mainWindow.on('leave-html-full-screen'", '});');
   assert.match(leaveHtmlFullscreen, /sendWindowState\(mainWindow\);/);
 });
 
-test('边界已经到位时不重复 setBounds，但仍然同步窗口状态', () => {
+test('边界还原按上游无条件执行，并同步窗口状态', () => {
   const main = readProjectFile('desktop/main.js');
   const target = { x: 160, y: 90, width: 1600, height: 900 };
-  const calls = { setBounds: 0, sendWindowState: 0, unmaximize: 0 };
+  const calls = { setBounds: 0, sendWindowState: 0, unmaximize: 0, guard: [] };
   const scope = {
     screen: { getDisplayMatching: () => ({ workArea: target }), getPrimaryDisplay: () => ({ workArea: target }) },
     windowedMinimumSize: () => ({ width: 960, height: 540 }),
     getWindowedBounds: () => ({ ...target }),
+    setMainWindowFullscreenResizeGuard: (_win, fullscreen) => calls.guard.push(fullscreen),
     sendWindowState: () => { calls.sendWindowState += 1; },
   };
   vm.runInNewContext(
-    `${readSourceBlock(main, 'function applyWindowedBounds(', 'function keepMainWindowInsideDisplay(')}
+    `${readSourceBlock(main, 'function applyWindowedBounds(', '/**')}
     this.apply = applyWindowedBounds;`,
     scope,
   );
@@ -221,11 +231,12 @@ test('边界已经到位时不重复 setBounds，但仍然同步窗口状态', (
   };
 
   scope.apply(win);
-  assert.equal(calls.setBounds, 0, '边界一致时不应再 setBounds');
+  assert.equal(calls.setBounds, 1, '上游无条件还原边界');
   assert.equal(calls.sendWindowState, 1);
+  assert.deepEqual(calls.guard, [false], '还原窗口态时必须放开尺寸锁');
 
   bounds.width = 1280;
   scope.apply(win);
-  assert.equal(calls.setBounds, 1, '边界不一致时仍要还原');
+  assert.equal(calls.setBounds, 2);
   assert.equal(calls.sendWindowState, 2);
 });

--- a/tests/fullscreen-upstream-parity.test.js
+++ b/tests/fullscreen-upstream-parity.test.js
@@ -1,0 +1,300 @@
+'use strict';
+// 全屏进入 / 退出与上游 XxHuberrr/Mineradio 对齐的部分。
+// 这一轮补齐三件上游有、本仓库没有的东西：全屏期间的尺寸锁、进入全屏前的显示器夹回、
+// 以及「全屏状态还在但窗口已经不可见」的可见性看门狗（那正是一整块黑屏的一个来源）。
+// 测试按锚点把 desktop/main.js 的真实实现切进 node:vm，不复制第二份逻辑。
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const MAIN_SOURCE = fs.readFileSync(path.join(__dirname, '..', 'desktop', 'main.js'), 'utf8');
+
+/**
+ * 按起止锚点截取主进程源码。锚点消失时立刻报错，提醒同步测试。
+ * @param {string} startMarker 起始锚点。
+ * @param {string} endMarker 结束锚点。
+ * @returns {string} 源码片段。
+ */
+function slice(startMarker, endMarker) {
+  const start = MAIN_SOURCE.indexOf(startMarker);
+  const end = MAIN_SOURCE.indexOf(endMarker, start + 1);
+  assert.ok(start >= 0 && end > start, `未找到源码块: ${startMarker}`);
+  return MAIN_SOURCE.slice(start, end);
+}
+
+/**
+ * 造一个可控的 setInterval 台面，记录周期并允许手工打点。
+ * @returns {{setInterval: Function, clearInterval: Function, jobs: Array, cleared: Array}} 定时器台面。
+ */
+function createIntervalBench() {
+  const jobs = [];
+  const cleared = [];
+  return {
+    jobs,
+    cleared,
+    setInterval(fn, period) {
+      const token = { fn, period, unrefed: false, unref() { this.unrefed = true; return this; } };
+      jobs.push(token);
+      return token;
+    },
+    clearInterval(token) { cleared.push(token); },
+  };
+}
+
+/**
+ * 在隔离 VM 里跑真实的全屏可见性看门狗实现。
+ * @param {object} [overrides] 覆盖 VM 作用域里的变量，例如 appQuitting。
+ * @returns {object} 探针、假窗口、定时器台面与调用记录。
+ */
+function createVisibilityHarness(overrides) {
+  const bench = createIntervalBench();
+  const logs = [];
+  const calls = { showInactive: 0, show: 0, windowState: 0 };
+  const win = {
+    destroyed: false,
+    fullscreen: true,
+    minimized: false,
+    visible: false,
+    showInactiveThrows: false,
+    isDestroyed() { return this.destroyed; },
+    isFullScreen() { return this.fullscreen; },
+    isMinimized() { return this.minimized; },
+    isVisible() { return this.visible; },
+    showInactive() {
+      if (this.showInactiveThrows) throw new Error('showInactive 炸了');
+      calls.showInactive += 1;
+      this.visible = true;
+    },
+    show() { calls.show += 1; this.visible = true; },
+  };
+  const ctx = Object.assign({
+    console: { warn: (...args) => logs.push(args.join(' ')) },
+    setInterval: bench.setInterval,
+    clearInterval: bench.clearInterval,
+    appQuitting: false,
+    mainWindowIntentionalHide: false,
+    mainWindowFullscreenVisibilityTimer: null,
+    sendWindowState() { calls.windowState += 1; },
+  }, overrides || {});
+  vm.createContext(ctx);
+  vm.runInContext(`${slice('const FULLSCREEN_VISIBILITY_CHECK_MS', '// 主窗口绘制恢复。')}
+globalThis.__probe = {
+  period: FULLSCREEN_VISIBILITY_CHECK_MS,
+  clear: clearMainWindowFullscreenVisibilityGuard,
+  should: shouldRestoreUnexpectedFullscreenVisibility,
+  restore: restoreUnexpectedFullscreenVisibility,
+  start: startMainWindowFullscreenVisibilityGuard,
+  get timer() { return mainWindowFullscreenVisibilityTimer; },
+};`, ctx);
+  return { api: ctx.__probe, ctx, bench, logs, calls, win };
+}
+
+/**
+ * 单独跑尺寸锁实现，记录每次 setResizable 的入参。
+ * @param {boolean|undefined} resizable 假窗口当前的可调整状态。
+ * @returns {object} 探针与调用记录。
+ */
+function createResizeGuardHarness(resizable) {
+  const logs = [];
+  const applied = [];
+  const win = {
+    resizable,
+    throws: false,
+    isDestroyed: () => false,
+    isResizable() { return this.resizable; },
+    setResizable(next) {
+      if (this.throws) throw new Error('setResizable 炸了');
+      applied.push(next);
+      this.resizable = next;
+    },
+  };
+  const ctx = { console: { warn: (...args) => logs.push(args.join(' ')) } };
+  vm.createContext(ctx);
+  vm.runInContext(`${slice('function setMainWindowFullscreenResizeGuard(', 'function applyWindowedBounds(')}
+globalThis.__guard = setMainWindowFullscreenResizeGuard;`, ctx);
+  return { guard: ctx.__guard, win, applied, logs };
+}
+
+test('全屏期间锁住尺寸，退出全屏时放开', () => {
+  const lock = createResizeGuardHarness(true);
+  lock.guard(lock.win, true);
+  assert.deepEqual(lock.applied, [false]);
+
+  const unlock = createResizeGuardHarness(false);
+  unlock.guard(unlock.win, false);
+  assert.deepEqual(unlock.applied, [true]);
+});
+
+test('状态已经对了就不再调用原生 API，销毁的窗口直接跳过', () => {
+  const already = createResizeGuardHarness(false);
+  already.guard(already.win, true);
+  assert.deepEqual(already.applied, [], '重复下发 setResizable 会白白触发一次窗口样式重算');
+
+  const gone = createResizeGuardHarness(true);
+  gone.win.isDestroyed = () => true;
+  gone.guard(gone.win, true);
+  assert.deepEqual(gone.applied, []);
+  gone.guard(null, true);
+  gone.guard(undefined, false);
+});
+
+test('setResizable 抛异常时吞掉并按方向记一行日志', () => {
+  const h = createResizeGuardHarness(true);
+  h.win.throws = true;
+  h.guard(h.win, true);
+  assert.equal(h.logs.length, 1);
+  assert.match(h.logs[0], /WindowResizeGuard.*fullscreen-lock/);
+
+  const back = createResizeGuardHarness(false);
+  back.win.throws = true;
+  back.guard(back.win, false);
+  assert.match(back.logs[0], /WindowResizeGuard.*windowed-restore/);
+});
+
+test('老版本 Electron 没有 isResizable 时直接下发', () => {
+  const h = createResizeGuardHarness(true);
+  h.win.isResizable = undefined;
+  h.guard(h.win, true);
+  assert.deepEqual(h.applied, [false]);
+});
+
+test('全屏还在但窗口不可见才算异常，其它状态一概不抢前台', () => {
+  const h = createVisibilityHarness();
+  assert.equal(h.api.should(h.win), true);
+
+  h.win.visible = true;
+  assert.equal(h.api.should(h.win), false, '窗口本来就看得见');
+  h.win.visible = false;
+
+  h.win.minimized = true;
+  assert.equal(h.api.should(h.win), false, '用户自己最小化的不算异常');
+  h.win.minimized = false;
+
+  h.win.fullscreen = false;
+  assert.equal(h.api.should(h.win), false, '普通窗口态的隐藏不在看门狗职责内');
+  h.win.fullscreen = true;
+
+  h.win.destroyed = true;
+  assert.equal(h.api.should(h.win), false);
+  h.win.destroyed = false;
+
+  assert.equal(h.api.should(null), false);
+  assert.equal(h.api.should(undefined), false);
+});
+
+test('退出中或用户主动收进托盘时看门狗不动手', () => {
+  const quitting = createVisibilityHarness({ appQuitting: true });
+  assert.equal(quitting.api.should(quitting.win), false);
+  assert.equal(quitting.api.restore(quitting.win, 'x'), false);
+  assert.equal(quitting.calls.showInactive, 0);
+
+  const trayed = createVisibilityHarness({ mainWindowIntentionalHide: true });
+  assert.equal(trayed.api.should(trayed.win), false);
+  assert.equal(trayed.api.restore(trayed.win, 'x'), false);
+  assert.equal(trayed.calls.showInactive, 0);
+});
+
+test('恢复用 showInactive，不抢焦点；抛异常时回落到 show', () => {
+  const h = createVisibilityHarness();
+  assert.equal(h.api.restore(h.win, 'system-resume'), true);
+  assert.equal(h.calls.showInactive, 1);
+  assert.equal(h.calls.show, 0, 'show() 会把窗口抢到前台并夺走焦点');
+  assert.equal(h.calls.windowState, 1);
+  assert.equal(h.logs.length, 1);
+  assert.match(h.logs[0], /WindowRecovery.*system-resume/);
+
+  const fallback = createVisibilityHarness();
+  fallback.win.showInactiveThrows = true;
+  assert.equal(fallback.api.restore(fallback.win), true);
+  assert.equal(fallback.calls.showInactive, 0);
+  assert.equal(fallback.calls.show, 1);
+});
+
+test('看门狗按 5 秒周期打点，且 unref 过不吊住进程退出', () => {
+  const h = createVisibilityHarness();
+  assert.equal(h.api.period, 5000);
+
+  h.api.start(h.win);
+  assert.equal(h.bench.jobs.length, 1);
+  assert.equal(h.bench.jobs[0].period, 5000);
+  assert.equal(h.bench.jobs[0].unrefed, true);
+
+  h.bench.jobs[0].fn();
+  assert.equal(h.calls.showInactive, 1);
+  assert.match(h.logs[0], /fullscreen-watchdog/);
+});
+
+test('重复启动只留最后一只，清理会把定时器槽复位', () => {
+  const h = createVisibilityHarness();
+  h.api.start(h.win);
+  const first = h.api.timer;
+  h.api.start(h.win);
+  assert.deepEqual(h.bench.cleared, [first], '旧的看门狗必须先停掉');
+  assert.notEqual(h.api.timer, first);
+
+  const second = h.api.timer;
+  h.api.clear();
+  assert.deepEqual(h.bench.cleared, [first, second]);
+  assert.equal(h.api.timer, null);
+
+  // 没有在跑的时候清理是安全的，也不会误调 clearInterval。
+  h.api.clear();
+  assert.equal(h.bench.cleared.length, 2);
+
+  // 窗口已经销毁时不布置看门狗，但仍然会先停掉旧的。
+  h.api.start(h.win);
+  const third = h.api.timer;
+  h.win.destroyed = true;
+  h.api.start(h.win);
+  assert.deepEqual(h.bench.cleared, [first, second, third]);
+  assert.equal(h.api.timer, null);
+});
+
+// 下面几条盯的是接线：实现写得再对，没挂到全屏事件上也救不了黑屏。
+test('四个全屏事件都带上尺寸锁，进入原生全屏时启动看门狗', () => {
+  const enter = slice("mainWindow.on('enter-full-screen'", '});');
+  assert.match(enter, /setMainWindowFullscreenResizeGuard\(mainWindow, true\);/);
+  assert.match(enter, /startMainWindowFullscreenVisibilityGuard\(mainWindow\);/);
+
+  const leave = slice("mainWindow.on('leave-full-screen'", '});');
+  assert.match(leave, /setMainWindowFullscreenResizeGuard\(mainWindow, false\);/);
+  assert.match(leave, /clearMainWindowFullscreenVisibilityGuard\(\);/);
+
+  const enterHtml = slice("mainWindow.on('enter-html-full-screen'", '});');
+  assert.match(enterHtml, /setMainWindowFullscreenResizeGuard\(mainWindow, true\);/);
+
+  const leaveHtml = slice("mainWindow.on('leave-html-full-screen'", '});');
+  assert.match(leaveHtml, /setMainWindowFullscreenResizeGuard\(mainWindow, false\);/);
+});
+
+test('窗口关闭、重建窗口时看门狗都会被停掉', () => {
+  const closed = slice("mainWindow.on('closed'", 'mainWindow = null;');
+  assert.match(closed, /clearMainWindowFullscreenVisibilityGuard\(\);/);
+
+  const created = slice('async function createWindow()', 'const preferredPort');
+  assert.match(created, /mainWindowIntentionalHide = false;/);
+  assert.match(created, /clearMainWindowFullscreenVisibilityGuard\(\);/);
+});
+
+test('收进托盘算主动隐藏，重新显示时解除标记', () => {
+  const closing = slice('const canKeepRunning =', 'miniPlayerActive = false;');
+  assert.match(closing, /mainWindowIntentionalHide = true;/);
+  assert.match(closing, /clearMainWindowFullscreenVisibilityGuard\(\);/);
+
+  const focus = slice('function focusMainWindow()', '\n}');
+  assert.match(focus, /mainWindowIntentionalHide = false;/);
+});
+
+test('睡眠回来和解锁屏幕都补一次全屏可见性恢复', () => {
+  assert.match(
+    MAIN_SOURCE,
+    /powerMonitor\.on\('resume', \(\) => restoreUnexpectedFullscreenVisibility\(mainWindow, 'system-resume'\)\)/,
+  );
+  assert.match(
+    MAIN_SOURCE,
+    /powerMonitor\.on\('unlock-screen', \(\) => restoreUnexpectedFullscreenVisibility\(mainWindow, 'screen-unlock'\)\)/,
+  );
+});

--- a/tests/fullscreen-window-behavior.test.js
+++ b/tests/fullscreen-window-behavior.test.js
@@ -410,7 +410,7 @@ test('Windows 原生移动循环在跨窗口前切换桌面歌词穿透', () => 
   assert.deepEqual(calls, ['begin', 'release', 'state']);
 });
 
-test('透明窗口退出逻辑全屏时仍调用原生退出 API', () => {
+test('只有逻辑全屏标记时按上游走边界还原，不再空调一次原生退出', () => {
   const source = readMainSource();
   const context = createTransparentFullscreenWindow();
   const timers = [];
@@ -419,6 +419,40 @@ test('透明窗口退出逻辑全屏时仍调用原生退出 API', () => {
   const scope = {
     windowFullscreenActive: true,
     htmlFullscreenActive: false,
+    setMainWindowFullscreenResizeGuard: () => {},
+    applyWindowedBounds: () => { context.calls.setBounds += 1; },
+    sendWindowState: () => {},
+    setTimeout: (handler) => { timers.push(handler); return timers.length; },
+    console,
+  };
+  vm.runInNewContext(
+    extractFunction(source, 'exitFullscreenToWindow', 'toggleFullscreen')
+      + '\nthis.exit = exitFullscreenToWindow;',
+    scope,
+  );
+
+  // 上游 exitFullscreenToWindow 只看 isFullScreen()：原生全屏没生效时直接还原边界。
+  scope.exit(context.win);
+
+  assert.deepEqual(context.calls.setFullScreen, []);
+  assert.equal(scope.windowFullscreenActive, false);
+  assert.equal(context.calls.setBounds, 1);
+  assert.equal(events['leave-full-screen'], undefined);
+  assert.equal(timers.length, 0);
+});
+
+test('退出原生全屏只调一次原生 API，不再补第二次延迟还原', () => {
+  const source = readMainSource();
+  const context = createTransparentFullscreenWindow();
+  const guard = [];
+  const timers = [];
+  const events = {};
+  context.win.isFullScreen = () => true;
+  context.win.once = (name, handler) => { events[name] = handler; };
+  const scope = {
+    windowFullscreenActive: true,
+    htmlFullscreenActive: false,
+    setMainWindowFullscreenResizeGuard: (_win, fullscreen) => guard.push(fullscreen),
     applyWindowedBounds: () => { context.calls.setBounds += 1; },
     sendWindowState: () => {},
     setTimeout: (handler) => { timers.push(handler); return timers.length; },
@@ -434,13 +468,38 @@ test('透明窗口退出逻辑全屏时仍调用原生退出 API', () => {
 
   assert.deepEqual(context.calls.setFullScreen, [false]);
   assert.equal(scope.windowFullscreenActive, false);
-  assert.equal(typeof events['leave-full-screen'], 'function');
-  assert.equal(timers.length, 1);
+  assert.deepEqual(guard, [false], '退出前必须先放开尺寸锁');
+  // 权威的 leave-full-screen 事件负责还原边界；这里再补一次会变成 move/resize 风暴。
+  assert.equal(events['leave-full-screen'], undefined);
+  assert.equal(timers.length, 0);
+  assert.equal(context.calls.setBounds, 0);
+});
 
-  events['leave-full-screen']();
-  assert.equal(timers.length, 2);
-  timers.forEach((handler) => handler());
-  assert.equal(context.calls.setBounds, 1);
+test('进入全屏前先把窗口夹回显示器，再锁住尺寸', () => {
+  const source = readMainSource();
+  const context = createTransparentFullscreenWindow();
+  const order = [];
+  const scope = {
+    windowFullscreenActive: false,
+    htmlFullscreenActive: false,
+    keepMainWindowInsideDisplay: () => order.push('clamp'),
+    setMainWindowFullscreenResizeGuard: (_win, fullscreen) => order.push(fullscreen ? 'lock' : 'unlock'),
+    exitFullscreenToWindow: () => order.push('exit'),
+    sendWindowState: () => order.push('state'),
+    console,
+  };
+  vm.runInNewContext(
+    extractFunction(source, 'toggleFullscreen', 'shouldExitWindowFullscreenFromInput')
+      + '\nthis.toggle = toggleFullscreen;',
+    scope,
+  );
+
+  scope.toggle(context.win);
+
+  // 夹回必须发生在置位全屏标记之前，否则 keepMainWindowInsideDisplay 会因为标记直接返回。
+  assert.deepEqual(order, ['clamp', 'lock', 'state']);
+  assert.equal(scope.windowFullscreenActive, true);
+  assert.deepEqual(context.calls.setFullScreen, [true]);
 });
 
 test('Esc 会退出透明窗口的逻辑全屏状态', () => {


### PR DESCRIPTION
## 起因

用户要求：全屏与退出全屏的处理与上游 `XxHuberrr/Mineradio` 一模一样。

拉了上游 `desktop/main.js`（5693 行）逐段对照全屏路径，补齐上游有、本仓库没有的三件东西，并删掉本仓库自己长出来的一次重复边界还原。

## 补齐

**尺寸锁 `setMainWindowFullscreenResizeGuard`**
原生全屏时窗口仍是 resizable，Windows 会把全屏尺寸当成一次用户 resize 反复回灌，和边界还原互相拉扯。四个全屏事件、`applyWindowedBounds`、`exitFullscreenToWindow`、`toggleFullscreen` 全部接上。状态已对时不重复下发（省一次窗口样式重算），老版本 Electron 缺 `isResizable` 时直接下发。

**全屏可见性看门狗（5s，`unref`）**
全屏状态还在、窗口却已经不可见 —— 这正是一整块黑屏的一个来源，而且不会自己回来。用 `showInactive()` 拉回，不抢焦点；`showInactive` 抛异常回落到 `show()`。退出中、用户主动收进托盘（`mainWindowIntentionalHide`）、最小化、普通窗口态一概不动手。`powerMonitor` 的 `resume` / `unlock-screen` 各补一次即时恢复。

**进入全屏前的显示器夹回**
`toggleFullscreen` 先 `keepMainWindowInsideDisplay(win)` 再置位 `windowFullscreenActive` —— 顺序反了夹回会因为标记直接 return。

## 去掉

`exitFullscreenToWindow` 里的 `once('leave-full-screen')` + 500ms 兜底，以及 `applyWindowedBounds` 的 `settled` 短路。边界还原只由权威的 `leave-full-screen` 安排一次。上游在同一位置留了原话：保留第二次延迟还原会造成 move/resize 风暴，一次用户操作可能触发两次原生 WE 重建。

顺带一个行为变化：`isFullScreen()` 为 false 但 `windowFullscreenActive` 为 true 时（透明无边框窗口的边缘情况），不再空调一次 `setFullScreen(false)`，按上游只走 `applyWindowedBounds`。

## 保留的差异

| 差异 | 理由 |
| --- | --- |
| 两个 leave 事件里立刻 `sendWindowState` | 本仓库多一层全屏过渡遮罩，晚推一次状态就多黑 50ms。已验证上游 `public/index.html` 里 `fullscreen-transition` 命中数为 0，渲染层没有这层遮罩。 |
| `shouldExitWindowFullscreenFromInput` 带 `!htmlFullscreenActive` | 上游只看 `win.isFullScreen()`；照抄会在 HTML 全屏时截走 Esc，挡掉 Chromium 自己的退出。两条既有测试钉着。 |
| `keepMainWindowInsideDisplay` 而非上游 `ensureMainWindowInsideDisplay` | 本仓库这只额外跳过最大化窗口、并额外看 `htmlFullscreenActive`。 |
| WE 边界重启不另接 | `wallpaperEngineBridge.attachWindow(mainWindow)` 已经挂了同样这四个事件。 |
| `fullDesktopModeRuntime` IPC 门不移植 | 该子系统本仓库不存在。 |
| 看门狗用模块级 `mainWindowIntentionalHide` | 上游用 `win.__mineradioIntentionalHide`；同时省掉上游的 `fullDesktopModeHostVisibilityTransitionDepth` 检查（无该子系统）。 |

## 测试

`node --test --test-concurrency=1` → **1047/1047 通过**（基线 1032）。

新增 `tests/fullscreen-upstream-parity.test.js` 13 条，按锚点把 `desktop/main.js` 的真实实现切进 `node:vm`，不复制第二份逻辑：尺寸锁四种路径、看门狗的状态判定 / 恢复方式 / 周期 / `unref` / 重复启动去重 / 清理复位，外加六条接线断言（四个全屏事件、`closed`、托盘隐藏、`focusMainWindow`、`createWindow`、两个 `powerMonitor`）。

改写的既有测试：`fullscreen-window-behavior` 把「透明窗口退出逻辑全屏时仍调用原生退出 API」换成三条（逻辑标记走边界还原 / 原生退出只调一次 / 进入全屏的夹回-加锁顺序）；`fullscreen-exit-transition` 钉住单航班还原与无条件 `setBounds`。

## 未验证

只做到单元层，本轮没有在真实 Electron 窗口上跑过全屏进出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
