### PR TITLE
fix(release): write checksum into dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
             $hash = (Get-FileHash $file -Algorithm SHA256).Hash.ToLower()
             "$hash *$file"
           }
-          $checksumPath = "Mineradio-oirge-$version-SHA256SUMS.txt"
+          $checksumPath = Join-Path (Get-Location) "Mineradio-oirge-$version-SHA256SUMS.txt"
           $content = ($lines -join "`n") + "`n"
           [IO.File]::WriteAllText(
             $checksumPath,

--- a/tests/github-actions-ci.test.js
+++ b/tests/github-actions-ci.test.js
@@ -38,6 +38,7 @@ test('发布工作流清单覆盖全部自动更新资产', () => {
   assert.match(releaseWorkflow, /"latest\.yml"/);
   assert.match(releaseWorkflow, /\$lines = foreach \(\$file in \$files\)/);
   assert.match(releaseWorkflow, /"\$hash \*\$file"/);
+  assert.match(releaseWorkflow, /\$checksumPath = Join-Path \(Get-Location\) "Mineradio-oirge-\$version-SHA256SUMS\.txt"/);
   assert.match(releaseWorkflow, /\[IO\.File\]::WriteAllText\(/);
   assert.match(releaseWorkflow, /\[Text\.UTF8Encoding\]::new\(\$false\)/);
   assert.match(releaseWorkflow, /\(\$lines -join "`n"\) \+ "`n"/);


### PR DESCRIPTION
## Summary
- keep the checksum file in `dist` after changing into that directory
- add a workflow regression assertion for the resolved checksum path

## Root cause
The first v2.0.3 release run built the installer successfully but wrote the checksum through a relative .NET path resolved from the process working directory, so the upload step could not find `dist/Mineradio-oirge-2.0.3-SHA256SUMS.txt`.

## Test plan
- [x] `node --test --test-concurrency=1 tests/github-actions-ci.test.js`
- [x] parse `.github/workflows/release.yml` with the installed YAML parser
- [x] `git diff --check`