### PR TITLE
docs(release): 记录 v2.0.4 发布资产与校验

### DIFF
--- a/AI_HANDOFF.md
+++ b/AI_HANDOFF.md
@@ -6,7 +6,8 @@
 
 - **仓库以 GitHub `https://github.com/oirge/Mineradio` 为准，本地路径随机器变化**。旧规则里的 `C:\Users\oirg\Desktop\mok\Mineradio-sync`、`C:\Users\Administrator\Desktop\Mineradio-main`、`E:\桌面\播放器软件\Mineradio\resources\app` 在当前环境都不存在，别盲目切过去；先 `git remote -v` + `git log --oneline -1` 确认。
 - 当前源码版本是 `v2.0.4`（文档编码修复与发布记录回填，纯维护版、无运行时改动），最新提交以 `git log --oneline -5 --decorate` 为准。
-- 发布基线：`v2.0.3` 已发布到 GitHub Release 并设为 Latest：`https://github.com/oirge/Mineradio/releases/tag/v2.0.3`（annotated tag object `ac634a30…` 指向 release commit `30b3ba5`，Release `386043356`，`published_at` `2026-09-10T06:22:41Z`）；四项资产已回下载核对一致。
+- `v2.0.4` 已发布到 GitHub Release 并设为 Latest：`https://github.com/oirge/Mineradio/releases/tag/v2.0.4`（annotated tag object `dd3d39eb…` 指向 release commit `4982e8c`，Release `386309149`，`published_at` `2026-09-10T13:30:49Z`）；四项资产已回下载核对一致。
+- 上一版 `v2.0.3`（SSA 歌词与发布链路加固）= annotated tag object `ac634a30…` 指向 `30b3ba5f…`，Release `386043356`。
 - GitHub 仓库：`https://github.com/oirge/Mineradio`
 - `package.json` 的发布配置和软件内更新配置均指向 `oirge/Mineradio`。
 - 新对话优先读 `AGENTS.md`、`docs/PROJECT_MEMORY.md`、`docs/HANDOFF_NEXT_CHAT.md`；涉及 3D 歌单架、玻璃 SVG、发布或安装包时再读对应专项文档。本文件下面包含较早历史记录（只到 `v1.2.44`），不能覆盖上述文件的当前结论。
@@ -75,8 +76,9 @@
 
 ### 2026-09-10（v2.0.4 文档维护版）
 
-- 发布 `v2.0.4`（纯维护版、无运行时行为改动）：修复 `RELEASE.md` 自 v1.2.61 起被 GBK 误解码损坏的约 165 行发布说明（以 `95a36fb` 为干净底本，按 `CHANGELOG.md` 重建被误标的 v1.2.61 节）；新增 `tests/doc-encoding-integrity.test.js` 文档编码门禁并接入 `Verify`；回填 v2.0.3 资产记录、统一「准备中/尚未发布」措辞、修正项目记忆与交接文档里过期的路径、最近发布基线与自称当前版本的历史快照；修掉 `CHANGELOG.md` 里内容已发布却仍标 `## Unreleased` 的错标小节。
-- 上一版资产记录分支 `docs/release-assets-v203-fix` → PR [#75](https://github.com/oirge/Mineradio/pull/75) → merge commit `0380ce2`；本版走 `codex/release-v2.0.4`。
+- 发布 `v2.0.4`（纯维护版、无运行时行为改动）并设为 Latest。分支 `codex/release-v2.0.4` 单提交 `4982e8c` → PR [#76](https://github.com/oirge/Mineradio/pull/76) → merge commit `76dd6d4`；annotated tag object `dd3d39eb…`；`Build and Release` run `34482743650` 成功，无双草稿。四资产回下载三路校验通过（安装器 `919f415d…`）。
+- 内容：修复 `RELEASE.md` 自 v1.2.61 起被 GBK 误解码损坏的约 165 行发布说明（以 `95a36fb` 为干净底本，按 `CHANGELOG.md` 重建被误标的 v1.2.61 节）；新增 `tests/doc-encoding-integrity.test.js` 文档编码门禁并接入 `Verify`；回填 v2.0.3 资产记录、统一「准备中/尚未发布」措辞、修正项目记忆与交接文档里过期的路径与基线；修掉 `CHANGELOG.md` 里内容已发布却仍标 `## Unreleased` 的错标小节。
+- 上一版资产记录分支 `docs/release-assets-v203-fix` → PR [#75](https://github.com/oirge/Mineradio/pull/75) → merge commit `0380ce2`。
 - 全量 Node 回归 `1076/1076` 通过（发布基线 `1071` + 新增 5 例编码门禁）；`node --check` 五个入口与 `git diff --check` 全清。未启动本机 Electron、未杀用户进程。
 
 ### 2026-09-10（v2.0.3 已发布 + RELEASE.md 编码损坏修复）

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,8 +10,25 @@
 
 ### 发布记录（v2.0.4）
 
-- 单分支 `codex/release-v2.0.4`。承接上一版资产记录分支 `docs/release-assets-v203-fix` → PR [#75](https://github.com/oirge/Mineradio/pull/75) → merge commit `0380ce2`（三个提交：`c091708` 编码修复与资产回填、`0a76e03` 项目记忆修正、`ba5a958` AGENTS 路径修正；`Verify` run `34478977406` / `34480225831` / `34480702584` / `34481205534` 均通过）。
-- 本节其余发布事实（tag object、`Build and Release` run、四项资产字节与 SHA256）在发布当轮补记；本仓库规矩是发布记录当轮写完，不留事后补写。
+- 上一版资产记录先收尾：`docs/release-assets-v203-fix` → PR [#75](https://github.com/oirge/Mineradio/pull/75) → merge commit `0380ce2`（三个提交 `c091708` / `0a76e03` / `ba5a958`；`Verify` run `34478977406` / `34480225831` / `34480702584` / `34481205534` 均通过）。
+- 本版单分支 `codex/release-v2.0.4`，单个提交 `4982e8c chore(release): 2.0.4`；PR [#76](https://github.com/oirge/Mineradio/pull/76) 用 merge commit 合入 `main`，合并提交 `76dd6d4`；`Verify` run `34482336528` / `34482364819` 过 PR、`34482576523` 过 `main`（`13:25:45Z`），均通过。
+- annotated tag `v2.0.4` = tag object `dd3d39eba43ae1c051b9c89af8c810355fe9b2c7`，指向 release commit `4982e8c5afb6697ee8001be394f2c3fd5883a261`；`git merge-base --is-ancestor` 复验该提交是 `origin/main` 祖先（打 tag 前 `git describe origin/main` 回 `v2.0.3-9-g76dd6d4`，符合「上一个 tag 之后 9 个提交」）。
+- `Build and Release` run `34482743650` 成功（`--ref v2.0.4 -f tag=v2.0.4`，`13:27:21Z` 起 `13:29:40Z` 止），Windows x64 NSIS 在 GitHub Actions 远程构建；`Validate release metadata` 校验 tag 与 `package.json` 版本一致，`Generate SHA256 checksums` 与 `Upload release assets` 全成功。本轮没有在本机启动 Electron、没有关闭或重启正在使用的 Mineradio，也没有执行安装包。
+- **没有出现 electron-builder 双草稿。** 工作流先用 `--publish never` 构建，上传步骤枚举同 tag Release：无记录时只创建一个草稿（`386309149`）并上传四项资产，复验仓库草稿数为 `1`（该 tag 下），发布后为 `0`。
+- 正式发布 Release `386309149`，标题 `Mineradio v2.0.4：文档修复与发布链路维护`，`published_at` `2026-09-10T13:30:49Z`，非 draft / 非 prerelease；`releases/latest` 已复验指向 `v2.0.4`。
+- 四项资产全部回下载到系统临时目录复算（blockmap 与 `latest.yml` 因刚发布时 CDN 尚未就绪、改用 API asset 端点取回；安装器与清单从下载 URL 直接取回）：
+
+| 资产 | 字节 | SHA256 |
+| --- | ---: | --- |
+| `Mineradio-oirge-2.0.4-Setup.exe` | 102618034 | `919f415dd784a4caf097ddb6fc91d49981857fb89b8ffda7e4ae433477163920` |
+| `Mineradio-oirge-2.0.4-Setup.exe.blockmap` | 106723 | `e67841aa2a28d603c008744e20acba10a4c2307ec509139170d5f85b90026375` |
+| `Mineradio-oirge-2.0.4-SHA256SUMS.txt` | 282 | `0bac8ba004e9a3f18fdf6e341b4e5c88845a67f9769b00b6a6a18555b461002d` |
+| `latest.yml` | 359 | `fb258fb8751ddff9bf47a4c72ae60646c5d2f16c2486203f275cf6f3fd02ce97` |
+
+- 三路校验全部通过：① GitHub API 的四个 `digest` 与本机 SHA256 逐字相同、字节数一致；② 清单 `Mineradio-oirge-2.0.4-SHA256SUMS.txt` 里三条（安装器 / blockmap / `latest.yml`）`sha256sum -c` 全中；③ `latest.yml` 的 `version` / `path` 为 `2.0.4` / `Mineradio-oirge-2.0.4-Setup.exe`，`files[0].size` `102618034` 与安装器字节数相同，文件项与顶层 SHA512 都是 `aomwZODFBaflXufduID6/zctarU11BLscEarRpq7y+SiWJEuXD7kuyyOidzVODyoe93q2kfw5ufH8w/qBvcOpQ==`（`sha512sum` 十六进制先 `xxd -r -p` 再 `base64 -w0` 复算一致），`releaseDate` `2026-09-10T13:29:24.481Z`。
+- `SHA256SUMS.txt` 依旧是真 LF、无 BOM（`cat -A` 只见行尾 `$`、无 `^M`），`sha256sum -c` 可直接跑。
+- 安装器比 v2.0.3 大了 `414` 字节（102,617,620 → 102,618,034）；这一版只改了文档与版本字符串，体积几乎不变，符合预期。
+- 资产记录分支 `docs/release-assets-v204`（本条记录自己就在这个分支上，PR 与合并提交号下一版补记）。
 
 ## v2.0.3 SSA 歌词与发布链路加固
 

--- a/docs/HANDOFF_NEXT_CHAT.md
+++ b/docs/HANDOFF_NEXT_CHAT.md
@@ -27,9 +27,9 @@ Get-Content package.json -Encoding UTF8
 
 ## 当前状态
 
-- 当前版本：`v2.0.4`（文档编码修复与发布记录回填，纯维护版、无运行时改动）。上一版 `v2.0.3`（SSA 歌词与发布链路加固）。
+- 当前版本：`v2.0.4`（文档编码修复与发布记录回填，纯维护版、无运行时改动），已发布并设为 GitHub Latest。上一版 `v2.0.3`（SSA 歌词与发布链路加固）。
 - GitHub 仓库：`https://github.com/oirge/Mineradio`。`package.json` 发布配置 owner/repo 为 `oirge/Mineradio`。
-- 发布基线：`v2.0.3` 已发布并设为 Latest（annotated tag object `ac634a30…` 指向 `30b3ba5f…`，Release `386043356`）。`v2.0.4` 为纯文档维护版。
+- 发布基线：`v2.0.4` = annotated tag object `dd3d39eb…` 指向 release commit `4982e8c`，Release `386309149`；上一版 `v2.0.3` = tag object `ac634a30…` 指向 `30b3ba5f…`，Release `386043356`。
 - `main` 是发布线，发版走 `codex/release-vX.Y.Z` 分支 + PR（**用 merge commit 合，绝不 squash**，否则 tag 会离开 `main` 可达历史），tag 打在 release commit 上。
 - `package.json` 发布配置 owner/repo 已是 `oirge/Mineradio`。
 

--- a/docs/PROJECT_MEMORY.md
+++ b/docs/PROJECT_MEMORY.md
@@ -58,6 +58,7 @@
 - 编码门禁：新增 `tests/doc-encoding-integrity.test.js`，用反向变换（按 GBK 编码再按 UTF-8 解码）识别乱码，要求核心文档合法 UTF-8、无 U+FFFD、无乱码、无 BOM；接入 `Verify` 的 `Check document encoding` 步骤。对损坏文件命中 121 行、修复后 0 行。
 - 记录回填：补 `RELEASE.md` 的 v2.0.3 发布记录；统一 v2.0.3「准备中/尚未发布」措辞；修正本文件 Stable Project Facts 里过期的本机路径、最近发布基线（`v1.6.1` → `v2.0.3`）与自称当前版本的历史快照；交接文档 `AI_HANDOFF.md` / `docs/HANDOFF_NEXT_CHAT.md` 更新到 v2 线；修掉 `CHANGELOG.md` 中内容已发布却仍标 `## Unreleased` 的错标小节。
 - 验证：全量 Node 回归 `1076/1076`（发布基线 `1071` + 新增 5 例编码门禁）；`node --check` 与 `git diff --check` 全清。
+- 发布：分支 `codex/release-v2.0.4`，单提交 `4982e8c`，PR #76 → merge commit `76dd6d4`；annotated tag object `dd3d39eb…` 指向 `4982e8c`；`Build and Release` run `34482743650` 成功（`13:27:21Z`–`13:29:40Z`）。**没有双草稿**（唯一草稿 `386309149` 上传四资产后发布）。Release `386309149` 标题 `Mineradio v2.0.4：文档修复与发布链路维护`，`published_at` `2026-09-10T13:30:49Z`，Latest=`v2.0.4`。四资产回下载三路校验通过：安装器 `102618034` / `919f415d…`、blockmap `106723` / `e67841aa…`、清单 `282` / `0bac8ba0…`、`latest.yml` `359` / `fb258fb8…`；`latest.yml` size `102618034`、sha512 `aomwZODF…` 与安装器一致，`releaseDate` `2026-09-10T13:29:24.481Z`。
 
 ## v2.0.3 SSA 歌词与发布链路加固
 


### PR DESCRIPTION
## 记录 v2.0.4 的发布资产与校验

在 `docs/release-assets-v204` 分支上回填 v2.0.4 发布记录，沿用本仓库「发布当轮写完」的规矩。

### 内容

- `RELEASE.md` 补全 `### 发布记录（v2.0.4）`：单提交 `4982e8c` → PR #76 → merge commit `76dd6d4`；annotated tag object `dd3d39eb…` 指向 release commit；`Build and Release` run `34482743650` 成功；无双草稿（唯一草稿 `386309149` 上传四资产后发布）；四项资产回下载三路校验结果。
- `docs/PROJECT_MEMORY.md`、`docs/HANDOFF_NEXT_CHAT.md`、`AI_HANDOFF.md` 记为已发布 Latest（Release `386309149`，`published_at` `2026-09-10T13:30:49Z`）。

### 校验结论

| 资产 | 字节 | SHA256 |
| --- | ---: | --- |
| `Mineradio-oirge-2.0.4-Setup.exe` | 102618034 | `919f415dd784a4caf097ddb6fc91d49981857fb89b8ffda7e4ae433477163920` |
| `Mineradio-oirge-2.0.4-Setup.exe.blockmap` | 106723 | `e67841aa2a28d603c008744e20acba10a4c2307ec509139170d5f85b90026375` |
| `Mineradio-oirge-2.0.4-SHA256SUMS.txt` | 282 | `0bac8ba004e9a3f18fdf6e341b4e5c88845a67f9769b00b6a6a18555b461002d` |
| `latest.yml` | 359 | `fb258fb8751ddff9bf47a4c72ae60646c5d2f16c2486203f275cf6f3fd02ce97` |

API `digest` 与本机 SHA256 逐字相同；清单 `sha256sum -c` 全中；`latest.yml` 的 size/sha512 与安装器一致。

纯文档改动，回归 `1076/1076` 通过；建议用 merge commit 合并。
