### PR TITLE
docs(release): 记录 v2.0.7 发布资产与校验

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,10 @@
 
 ## v2.0.7 3D 歌单架新增「舞台」原版风格
 
+- **发布结果（2026-09-11）**：tag `v2.0.7` → release commit `15804c9`（PR #81，merge `9103baa` 合入 `main`）；Release `386939633`，`published_at` `2026-09-11T10:05:24Z`，已设 Latest；构建 run `34587084479` 成功，四资产齐全。
+  - `Mineradio-oirge-2.0.7-Setup.exe` sha256 `58e3a12ef64cf119dac7508279d39ec9877b1a1236802e97b235d42f72b60f2f`（size 102649838）
+  - `Mineradio-oirge-2.0.7-Setup.exe.blockmap` sha256 `6293eee964d048d5c297093abb1cb1e7c34dfd96819c7c6f6af78e73e3e7288a`
+  - `latest.yml` sha256 `b70a182efc6116a1621d60704e360d59611461fb0c17b0ee3936453bafca4c25`（`version: 2.0.7`）
 - 发布版本从 `2.0.6` 提升为 `2.0.7`；五处版本钉（`package.json`、`package-lock.json` 两处、`public/app.js` 的 `APP_VERSION`、发布工作流默认 tag）一起动。安装身份、数据目录与自动更新线路保持不变。
 - 用户需求原话：「我要的是保留我这个原本的侧栏歌架单增加一个切换为舞台歌架单」、「和原项目舞台歌架单一模一样的效果」。**唯一模式仍是 `fx.shelf = off / side / stage`**，引擎由模式决定：`side` 走本仓库现有 `makeShelfManager()`（`shelfManagerDefault`），`stage` 走上游 XxHuberrr/Mineradio 原版实现（`public/shelf-classic.js` 的 `createClassicShelfEngine`，`shelfManagerClassic`）。
 - 切换入口两处：DIY 视觉控制台「3D / 手势」里原有的 `#shelf-seg` 三态 + 主界面底部控制条新增的 `#shelf-view-btn`（`toggleShelfStageMode()`）。**音量弹层不放歌单架入口**（用户明确否过），**也不再有「现有 / 原版」独立引擎开关**（首版那套已整体作废）。

--- a/docs/HANDOFF_NEXT_CHAT.md
+++ b/docs/HANDOFF_NEXT_CHAT.md
@@ -27,9 +27,9 @@ Get-Content package.json -Encoding UTF8
 
 ## 当前状态
 
-- 当前版本：`v2.0.7`（3D 歌单架新增「舞台」原版风格），版本钉已升，准备发布。
+- 当前版本：`v2.0.7`（3D 歌单架新增「舞台」原版风格），已发布。
 - GitHub 仓库：`https://github.com/oirge/Mineradio`。`package.json` 发布配置 owner/repo 为 `oirge/Mineradio`。
-- 正式发布基线：线上 Latest 是 `v2.0.6`（常用控制提到主界面 + 输出设备选择），Release `386831543`，`published_at` `2026-09-11T06:46:46Z`，四项资产齐全；tag `v2.0.6` 指向 release commit `ee69d5b`。上一版 `v2.0.5`（Release `386795754`，tag 指向 `23e9e81`）、更早 `v2.0.4`（Release `386780937`，tag 指向 `2966d52`）。
+- 正式发布基线：线上 Latest 是 `v2.0.7`（3D 歌单架舞台原版风格），Release `386939633`，`published_at` `2026-09-11T10:05:24Z`，四项资产齐全；tag `v2.0.7` 指向 release commit `15804c9`（PR #81 merge `9103baa`）。上一版 `v2.0.6`（Release `386831543`，tag 指向 `ee69d5b`）、更早 `v2.0.5`（Release `386795754`，tag 指向 `23e9e81`）。
 - `main` 是发布线，发版走 `codex/release-vX.Y.Z` 分支 + PR（**用 merge commit 合，绝不 squash**，否则 tag 会离开 `main` 可达历史），tag 打在 release commit 上。
 - `package.json` 发布配置 owner/repo 已是 `oirge/Mineradio`。
 
@@ -56,7 +56,7 @@ Get-Content package.json -Encoding UTF8
 
 ## 后续优先级
 
-- 无未完成的发布动作；`v2.0.6` 资产与文档都已回填。下一版起沿用 `codex/release-vX.Y.Z` 分支 + PR 的流程。
+- 无未完成的发布动作；`v2.0.7` 资产与文档都已回填。下一版起沿用 `codex/release-vX.Y.Z` 分支 + PR 的流程。
 - 长期方向（未排期）：IndexedDB `assets` 拆分 `lyrics` store 并做流式迁移；外置封面改走 `/api/local-file` 流式 URL，避免主进程完整 Buffer/base64 和 renderer data URL。
 - 观察项：`docs/HANDOFF_NEXT_CHAT.md` / `AI_HANDOFF.md` 的本地路径描述随机器变化，接手时先 `git remote -v` 核对，不要照抄旧路径。
 


### PR DESCRIPTION
回填 v2.0.7 的 tag、Release id、published_at、构建 run 与四资产 SHA256；更新 handoff 的当前版本与发布基线。纯文档，不改代码。