### PR TITLE
docs(release): 记录 v2.0.8 发布资产与校验

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,10 @@
 
 ## v2.0.8 Wallpaper Engine 壁纸导入弹窗样式修复
 
+- **发布结果（2026-09-12）**：tag `v2.0.8` → release commit `739d0cf`（PR #84，merge `8474d13` 合入 `main`）；Release `387419553`，`published_at` `2026-09-12T01:45:15Z`，已设 Latest；构建 run `34665588375` 成功，四资产齐全。
+  - `Mineradio-oirge-2.0.8-Setup.exe` sha256 `36bab4aa8aba9204d179bd1329c59a5cc745a8e8abaf71a5194fef0668fe677f`
+  - `Mineradio-oirge-2.0.8-Setup.exe.blockmap` sha256 `9c42adb3bd5b94abe80db7670147d546f0fbe7e3f3252645746b64f71405d68d`
+  - `latest.yml` sha256 `8d8b9e5df8e94def7d0d6394e5e3c328850c897ed656518ed006e52425861dee`（`version: 2.0.8`）
 - 发布版本从 `2.0.7` 提升为 `2.0.8`；五处版本钉（`package.json`、`package-lock.json` 两处、`public/app.js` 的 `APP_VERSION`、发布工作流默认 tag）一起动。安装身份、数据目录与自动更新线路保持不变。
 - 用户报告：WE 选择壁纸识别导入后，壁纸显示特别大、几乎只能看见一张、不能上下滚动选择。
 - 根因：`public/wallpaper-engine.css` 的 `body.custom-bg-glass-active #custom-bg::after` 规则**少一个收尾 `}`**，后面的 `.wallpaper-engine-row {` 被当嵌套规则，Chrome 的 CSS 嵌套把文件剩余全部规则（整个 `wallpaper-engine-library-modal` / `wallpaper-engine-grid` / `wallpaper-engine-card` 样式族）吞进这条永不匹配的规则。弹窗退回通用 `.modal`（380px 窄、高度随内容撑开）、卡片失去 16/9 四列布局、预览图按原始尺寸渲染——正好产出用户看到的现象。缺括号由 `7626bfb`（v1.4.3 首次添加该文件）引入，即该弹窗自 v1.4.3 起从未有过样式。

--- a/docs/HANDOFF_NEXT_CHAT.md
+++ b/docs/HANDOFF_NEXT_CHAT.md
@@ -27,9 +27,9 @@ Get-Content package.json -Encoding UTF8
 
 ## 当前状态
 
-- 当前版本：`v2.0.8`（Wallpaper Engine 壁纸导入弹窗样式修复），版本钉已升，准备发布。
+- 当前版本：`v2.0.8`（Wallpaper Engine 壁纸导入弹窗样式修复），已发布。
 - GitHub 仓库：`https://github.com/oirge/Mineradio`。`package.json` 发布配置 owner/repo 为 `oirge/Mineradio`。
-- 正式发布基线：线上 Latest 是 `v2.0.7`（3D 歌单架舞台原版风格），Release `386939633`，`published_at` `2026-09-11T10:05:24Z`，四项资产齐全；tag `v2.0.7` 指向 release commit `15804c9`（PR #81 merge `9103baa`）。上一版 `v2.0.6`（Release `386831543`，tag 指向 `ee69d5b`）、更早 `v2.0.5`（Release `386795754`，tag 指向 `23e9e81`）。
+- 正式发布基线：线上 Latest 是 `v2.0.8`（Wallpaper Engine 壁纸导入修复），Release `387419553`，`published_at` `2026-09-12T01:45:15Z`，四项资产齐全；tag `v2.0.8` 指向 release commit `739d0cf`（PR #84 merge `8474d13`）。上一版 `v2.0.7`（Release `386939633`，tag 指向 `15804c9`）、更早 `v2.0.6`（Release `386831543`，tag 指向 `ee69d5b`）。
 - `main` 是发布线，发版走 `codex/release-vX.Y.Z` 分支 + PR（**用 merge commit 合，绝不 squash**，否则 tag 会离开 `main` 可达历史），tag 打在 release commit 上。
 - `package.json` 发布配置 owner/repo 已是 `oirge/Mineradio`。
 
@@ -57,7 +57,7 @@ Get-Content package.json -Encoding UTF8
 
 ## 后续优先级
 
-- 无未完成的发布动作；`v2.0.7` 资产与文档都已回填。下一版起沿用 `codex/release-vX.Y.Z` 分支 + PR 的流程。
+- 无未完成的发布动作；`v2.0.8` 资产与文档都已回填。下一版起沿用 `codex/release-vX.Y.Z` 分支 + PR 的流程。
 - 长期方向（未排期）：IndexedDB `assets` 拆分 `lyrics` store 并做流式迁移；外置封面改走 `/api/local-file` 流式 URL，避免主进程完整 Buffer/base64 和 renderer data URL。
 - 观察项：`docs/HANDOFF_NEXT_CHAT.md` / `AI_HANDOFF.md` 的本地路径描述随机器变化，接手时先 `git remote -v` 核对，不要照抄旧路径。
 

--- a/docs/PROJECT_MEMORY.md
+++ b/docs/PROJECT_MEMORY.md
@@ -51,14 +51,14 @@
 
 ## Release Memory
 
-## 未发布修复：Wallpaper Engine 壁纸导入弹窗样式全失效（2026-09-11，工作区已改，未提交、未发版）
+## v2.0.8：Wallpaper Engine 壁纸导入弹窗样式全失效修复（已发布，2026-09-12）
 
 - 用户报告：WE「识别 / 导入」弹窗里壁纸特别大、几乎只能看见一张、不能上下滚动选择。
 - **根因是一处 CSS 缺右括号**：`public/wallpaper-engine.css` 里 `body.custom-bg-glass-active #custom-bg::after { ... backdrop-filter: ...;` 后**少了 `}`**，紧跟的 `.wallpaper-engine-row {` 被解析成嵌套规则；Chrome 的 CSS 嵌套把文件剩余全部顶层规则（`wallpaper-engine-library-modal` / `wallpaper-engine-grid` / `wallpaper-engine-card` 整族）吞进这条 `::after` 规则、永不匹配。于是弹窗退回通用 `.modal`（380px 窄、高度被内容撑到两屏多、遮罩不滚动）、卡片失去 16/9 四列、预览 `<img>` 按原始尺寸渲染成巨图——三件事拼出用户看到的现象。
 - **排查定式值得记**：页面"看起来有样式"不代表每个样式表都活着——`document.styleSheets` 里该表 `cssRules.length` 只有 16（实际 83 条），一条规则内语法错误会让 Chrome 按嵌套规则静默吞掉文件剩余部分，**不报任何错**。查 CSS「整段失效」先数 `cssRules.length`，再做括号配平。
 - 缺括号由 `7626bfb`（v1.4.3 首次添加该文件）引入——该弹窗自 v1.4.3 起从未有过样式。
 - 修复：补上 `}`。新增 `tests/wallpaper-engine-css-syntax.test.js` 3 例：花括号配平、弹窗关键选择器必须是**顶层**规则、布局约束（网格 `overflow:auto`、卡片 `calc((100% - 39px)/4)` 四列 + `16/9`、预览 `object-fit:cover`、弹窗 `height:min(820px,88vh)`）；对修前源码对跑 3 例全红、修后全绿。浏览器注入 30 个模拟项目实测布局恢复并截图确认。全量回归 `1139/1139`。
-- 版本保持 2.0.7，等用户授权发布后随下一版带上。
+- 版本 2.0.8 已在用户明确要求下发布（Release `387419553`，tag `v2.0.8` → `739d0cf`，已设 Latest，PR #84 merge `8474d13`）。
 
 ## v2.0.7 3D 歌单架「舞台档用原版」可切换（已发布）
 


### PR DESCRIPTION
回填 v2.0.8 的 tag、Release id、published_at、构建 run 与四资产 SHA256；更新 handoff 当前版本与发布基线、记忆文档发布状态。纯文档，不改代码。