### PR TITLE
docs: record v2.0.10 release assets

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,17 @@
 # 发布流程
 
+## v2.0.10 歌词显示与翻译 + Wallpaper Engine 选择入口修复
+
+- 发布版本从 `2.0.9` 提升为 `2.0.10`；五处版本钉（`package.json`、`package-lock.json` 两处、`public/app.js` 的 `APP_VERSION`、发布工作流 description+默认 tag）一起动。安装身份、数据目录与自动更新线路保持不变。
+- 内容：① 移植上游「显示与翻译」——歌词行数模式（单行/双行/三行/沉浸/自定）、显示行数、双语翻译模式（关闭/当前/双行/多行）、译文间距/字号/透明，默认 `cinema/multi/10/0.92/0.65/0.86` 逐字照上游；② 舞台歌词多行渲染——轻量行池（context/translation 两类 mesh）+ 轨道滚动缓动 + 译文子行四种门控（公式照上游）；③ 内置 LLM 翻译源——`/api/lyric-translate` 本地同源代理（端点不支持 CORS 预检，浏览器直连必挂；端点/key/模型由 server.js 持有）+ 行级内容寻址缓存（`mineradio-lyric-llm-translation-v1`，三处清单登记，同一句永不重翻）+ 英文 system prompt（中文 prompt 会被 grok-chat-fast 自由发挥或回显）+ 空译文空串缓存防无限重试；④ 修复 v2.0.8 引入的 WE「识别 / 导入」按钮溢出回归（actions clamp 宽度在 image-pick-row 第三列 68px 里装不下，WE 行专用三列布局）。
+- 测试：新增 `tests/lyric-display-translation.test.js` 11 例 + `tests/wallpaper-engine-row-layout.test.js` 3 例。全量 Node 回归 **1183/1183**（v2.0.9 基线 `1168`）。浏览器真机：真实 API 翻出 5 行中文并落盘、缓存命中零请求、cinema+multi 渲染截图（当前行高亮+译文子行+上下文渐隐）全过。
+- 发布结果（2026-09-12）：tag `v2.0.10` → release commit `3559edf`（PR #88，merge `3029b3b` 合入 `main`）；Release `387480927`，`published_at` `2026-09-12T06:44:57Z`，已设 Latest；构建 run `34678695171` 成功，四资产齐全。
+  - `Mineradio-oirge-2.0.10-Setup.exe` sha256 `40edc83b3774039a7d4185e6e41405cbf4350c8cd1a80a955679c53a178d5804`（size 102652262 以实际为准，实物回下载校验一致）
+  - `Mineradio-oirge-2.0.10-Setup.exe.blockmap` sha256 `0fd0cdeba7dfe8081a97913c9c2d6514b7c6da70976fc45cdee0d165db03adbb`
+  - `latest.yml` sha256 `080a0c5822dcc476fc76d47c35c40b310e81067bda56363e839f7dd13f933088`，`version: 2.0.10` 已核对
+  - `Mineradio-oirge-2.0.10-SHA256SUMS.txt` 清单与实物一致
+- 应用内更新公告四条，已经 `server.js` 真实 `extractReleaseNotes` 解析器预验证 4/4 保留。
+
 ## v2.0.9 玻璃与左栏参数组移植 + 隐藏右上角房子按钮
 
 - 发布版本从 `2.0.8` 提升为 `2.0.9`；五处版本钉（`package.json`、`package-lock.json` 两处、`public/app.js` 的 `APP_VERSION`、发布工作流默认 tag）一起动。安装身份、数据目录与自动更新线路保持不变。

--- a/docs/HANDOFF_NEXT_CHAT.md
+++ b/docs/HANDOFF_NEXT_CHAT.md
@@ -27,14 +27,15 @@ Get-Content package.json -Encoding UTF8
 
 ## 当前状态
 
-- 当前版本：`v2.0.10`（歌词显示与翻译 + LLM 翻译源 + WE 选择入口修复），发布中（详情发布后回填 RELEASE.md）。
+- 当前版本：`v2.0.10`（歌词显示与翻译 + LLM 翻译源 + WE 选择入口修复），已发布。
 - GitHub 仓库：`https://github.com/oirge/Mineradio`。`package.json` 发布配置 owner/repo 为 `oirge/Mineradio`。
-- 正式发布基线：线上 Latest 是 `v2.0.9`（玻璃与左栏参数组 + 隐藏房子按钮），Release `387445460`，`published_at` `2026-09-12T03:50:55Z`，四项资产齐全（Setup.exe sha256 `cf358317…` 实物校验一致）；tag `v2.0.9` 指向 release commit `ba7c46e`（PR #86 merge `02681cf`）。上一版 `v2.0.8`（Release `387419553`，tag 指向 `739d0cf`）、更早 `v2.0.7`（Release `386939633`，tag 指向 `15804c9`）。
+- 正式发布基线：线上 Latest 是 `v2.0.10`（歌词显示与翻译 + WE 选择入口修复），Release `387480927`，`published_at` `2026-09-12T06:44:57Z`，四项资产齐全（Setup.exe sha256 `40edc83b…` 实物校验一致）；tag `v2.0.10` 指向 release commit `3559edf`（PR #88 merge `3029b3b`）。上一版 `v2.0.9`（Release `387445460`，tag 指向 `ba7c46e`）、更早 `v2.0.8`（Release `387419553`，tag 指向 `739d0cf`）、更早 `v2.0.7`（Release `386939633`，tag 指向 `15804c9`）。
 - `main` 是发布线，发版走 `codex/release-vX.Y.Z` 分支 + PR（**用 merge commit 合，绝不 squash**，否则 tag 会离开 `main` 可达历史），tag 打在 release commit 上。
 - `package.json` 发布配置 owner/repo 已是 `oirge/Mineradio`。
 
 ## 最近完成
 
+- 2026-09-12：发布 `v2.0.10`（歌词显示与翻译 + LLM 翻译源 + WE 选择入口修复）。tag `v2.0.10` → `3559edf`（PR #88 merge `3029b3b`），Release `387480927` 已设 Latest，run `34678695171`，四资产齐全、SHA256 实物校验一致，`latest.yml` `version: 2.0.10`。公告四条过真实解析器 4/4。
 - 2026-09-12：移植上游「显示与翻译」（歌词行数模式/双语翻译模式/译文三滑条，默认 cinema/multi/10/0.92/0.65/0.86），多行语义用轻量行池在本仓库单 mesh 引擎上复刻；新增 LLM 翻译服务（用户端点走 `/api/lyric-translate` 本地代理，英文 system prompt，行级内容寻址缓存永不重翻）；修复 v2.0.8 引入的 WE「识别 / 导入」按钮溢出回归。测试 14 例，回归 `1183/1183`。**用户已授权发布 v2.0.10**。
 - 2026-09-12：按用户纠正把房子按钮从「直接删除」改为「原版同款把手控制」：恢复 `#home-btn`，新增 `#home-btn-hide-btn` 把手（`toggleHomeBtnAutoHide`，持久化 `mineradio-home-btn-auto-hide-v1`，四处同步键清单），`tests/home-btn-auto-hide.test.js` 3 例。回归 `1169/1169`。工作区改动未发版。
 - 2026-09-12：发布 `v2.0.9`（玻璃与左栏参数组移植 + 隐藏右上角房子按钮）。tag `v2.0.9` → `ba7c46e`（PR #86 merge `02681cf`），Release `387445460` 已设 Latest，run `34671295714`，四资产齐全、SHA256 三路校验一致，`latest.yml` `version: 2.0.9`。应用内公告四条过真实解析器 4/4 保留（解析器上限 4 条，正文不带标题行）。

--- a/docs/PROJECT_MEMORY.md
+++ b/docs/PROJECT_MEMORY.md
@@ -51,7 +51,7 @@
 
 ## Release Memory
 
-## v2.0.10：歌词「显示与翻译」移植 + LLM 翻译源 + WE 选择入口修复（发布中，2026-09-12）
+## v2.0.10：歌词「显示与翻译」移植 + LLM 翻译源 + WE 选择入口修复（已发布，2026-09-12）
 
 - 用户需求：「把原项目的这个功能移植过来，一模一样就行」，附上游「显示与翻译」组截图，并指定翻译源 `http://129.204.9.16:8000/v1` / 模型 `grok-chat-fast`；随后补「翻译过的歌词自动保存到本地防止多次翻译」与「修复选择壁纸的按钮不在了」。
 - **上游语义侦察结论**：上游「双语翻译」只是平台译文（tlyric/网易跨源回退）的显示模式系统，无 LLM 翻译；行数模式=轨道布局（single 1 / dual [0,1] 当前行在上 / triple 3 / cinema 5 且 context 行更实 / custom 1–10）。译文永远挂在父行正下方，四种模式差别只在注入策略与透明度门控（current 仅当前行、dual 下一行 0.56 半亮、multi 全显示随 parentFade）。
@@ -61,7 +61,7 @@
 - **缓存坑三连**：① `cacheDirty` 忘置 true → persist 永远 return、localStorage 恒空；② 仓库只有 `setPersistentLocalStorageItem`，读取端靠启动镜像灌回，没有 `getPersistentLocalStorageItem`（写了必 ReferenceError）；③ 缓存键登记三处（PERSISTENT_UI_STATE_KEYS/preload/main）。空译文写空串缓存防失败行无限重试。
 - **WE 按钮回归**：v2.0.8 恢复 wallpaper-engine.css 后 `.wallpaper-engine-actions` 宽度在 image-pick-row 第三列（68px）溢出，把「识别 / 导入」挤出面板——v2.0.8 引入的回归，WE 行专用三列布局修复。
 - 测试：`tests/lyric-display-translation.test.js` 11 例 + `tests/wallpaper-engine-row-layout.test.js` 3 例。浏览器真机：真实 API 翻 5 行中文、缓存命中零请求、cinema+multi 渲染截图全过。回归 `1183/1183`（v2.0.9 基线 `1168`）。
-- 发布门禁：**用户明确授权发布**（「然后再发布新版本」）；发版后补 RELEASE.md。
+- 发布门禁：**用户明确授权发布**（「然后再发布新版本」），已发布为 `v2.0.10`（Release `387480927`，tag → `3559edf`，PR #88 merge `3029b3b`，已设 Latest，run `34678695171`；Setup.exe sha256 `40edc83b…` 实物校验一致）。RELEASE.md 已回填。
 
 ## v2.0.9：玻璃与左栏参数组移植 + 隐藏右上角房子按钮（已发布，2026-09-12）
 


### PR DESCRIPTION
回填 v2.0.10 发布结果到 RELEASE.md，同步 HANDOFF / PROJECT_MEMORY（Release `387480927`、tag → `3559edf`、SHA256 校验、CORS/prompt/缓存三条经验记录）。