### PR TITLE
fix: 同步歌词行距辅助公式

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -10003,12 +10003,21 @@ function lyricRowVirtualIndex(row) {
   return row.kind === 'translation' ? primary + lyricTranslationVisualGapValue() : primary;
 }
 function lyricRowLineStepWorld(worldH) {
-  return clampRange(worldH * 0.34 * lyricContextSpreadFactor(), 0.22, 0.94);
+  var step = Number(worldH) || 0;
+  var lockFont = typeof LYRIC_ROW_LOCK_FONT === 'number' ? LYRIC_ROW_LOCK_FONT : 128;
+  step *= lockFont * lyricLineHeightFactor() / 384;
+  step *= lyricContextSpreadFactor();
+  if (lyricTranslationModeActive()) step *= 1.06;
+  return clampRange(step, 0.22, 0.94);
 }
 // Upstream uses a dedicated line-height for translation children. Reusing the
 // primary step makes the child drift from its parent during track scrolling.
 function lyricRowTranslationStepWorld(worldH) {
-  return clampRange(worldH * 0.34 * 1.04, 0.20, 0.78);
+  var step = Number(worldH) || 0;
+  var lockFont = typeof LYRIC_ROW_LOCK_FONT === 'number' ? LYRIC_ROW_LOCK_FONT : 128;
+  step *= lockFont * lyricLineHeightFactor() / 384;
+  if (lyricTranslationModeActive()) step *= 1.04;
+  return clampRange(step, 0.20, 0.78);
 }
 function lyricRowTranslationAnchoredY(row, scrollOffset, lineStepWorld, translationLineStepWorld, rowDrift, currentTranslation) {
   if (!row) return 0;


### PR DESCRIPTION
补齐上游行距辅助函数的公式：无译文按纯行高，翻译模式按 context spread、1.06 主行系数和 1.04 译文系数计算。运行时主路径已覆盖，同步辅助函数避免后续调用再次产生间距差异。

验证：node --check public/app.js；node tests/lyric-display-translation.test.js；npm test 1183/1183。
